### PR TITLE
Updated the .gitignore to exclude a temporary file from lein-retest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ syntax: glob
 *.pyc
 *.dot
 .cake/
-.lein_failures
+.lein-failures


### PR DESCRIPTION
In the latest version of lein-retest, the last set of namespaces with failed tests is tracked in a file named .lein-failures. This was being ignored previously with a slightly different file name.

https://github.com/technomancy/lein-retest/blob/1.0.1/README.md
