### PR TITLE
Added path-filter parameter to hfs-tap and lfs-tap

### DIFF
--- a/src/clj/cascalog/tap.clj
+++ b/src/clj/cascalog/tap.clj
@@ -21,11 +21,11 @@
   tap wrapped that responds as a `TemplateTap` when used as a sink,
   and a `GlobHfs` tap when used as a source. Otherwise, acts as
   identity."
-  [scheme type path-or-file sinkmode sink-template source-pattern templatefields]
+  [scheme type path-or-file sinkmode sink-template source-pattern templatefields path-filter]
   (let [tap-maker ({:hfs w/hfs :lfs w/lfs} type)
         parent (tap-maker scheme path-or-file sinkmode)
         source (if source-pattern
-                 (w/glob-hfs scheme path-or-file source-pattern)
+                 (w/glob-hfs scheme path-or-file source-pattern path-filter)
                  parent)
         sink (if sink-template
                (w/template-tap parent sink-template templatefields)
@@ -48,12 +48,15 @@
   used as a sink.
 
   `:templatefields` - When pattern is supplied via :sink-template, this option allows a
-  subset of output fields to be used in the naming scheme."
-  [scheme path-or-file :sinkmode nil :sinkparts nil :sink-template nil :source-pattern nil :templatefields Fields/ALL]
+  subset of output fields to be used in the naming scheme.
+  
+  `:path-filter` - an org.apache.hadoop.fs.PathFilter that filters source paths"
+
+  [scheme path-or-file :sinkmode nil :sinkparts nil :sink-template nil :source-pattern nil :templatefields Fields/ALL :path-filter nil]
   (-> scheme
       (w/set-sinkparts! sinkparts)
       (patternize :hfs path-or-file sinkmode
-                  sink-template source-pattern templatefields)))
+                  sink-template source-pattern templatefields path-filter)))
 
 (defnk lfs-tap
   "Returns a Cascading Lfs tap with support for the supplied scheme,
@@ -71,10 +74,12 @@
   used as a sink.
 
   `:templatefields` - When pattern is supplied via :sink-template, this option allows a
-  subset of output fields to be used in the naming scheme."
+  subset of output fields to be used in the naming scheme.
+
+  `:path-filter` - an org.apache.hadoop.fs.PathFilter that filters source paths"
   
-  [scheme path-or-file :sinkmode nil :sinkparts nil :sink-template nil :source-pattern nil :templatefields Fields/ALL]
+  [scheme path-or-file :sinkmode nil :sinkparts nil :sink-template nil :source-pattern nil :templatefields Fields/ALL :path-filter nil]
     (-> scheme
       (w/set-sinkparts! sinkparts)
       (patternize :lfs path-or-file sinkmode
-                  sink-template source-pattern templatefields)))
+                  sink-template source-pattern templatefields path-filter)))

--- a/src/clj/cascalog/workflow.clj
+++ b/src/clj/cascalog/workflow.clj
@@ -506,9 +506,14 @@ identity.  identity."
            (path path-or-file)
            (sink-mode sinkmode))))
 
-(defn glob-hfs [^Scheme scheme path-or-file source-pattern]
-  (GlobHfs. scheme (str (path path-or-file)
-                        source-pattern)))
+(defn glob-hfs
+  ([^Scheme scheme path-or-file source-pattern]
+    (GlobHfs. scheme (str (path path-or-file)
+                          source-pattern)))
+  ([^Scheme scheme path-or-file source-pattern path-filter]
+    (GlobHfs. scheme (str (path path-or-file)
+                          source-pattern)
+                          path-filter)))
 
 (defn template-tap
   ([^Hfs parent sink-template]


### PR DESCRIPTION
I added a parameter to hfs-tap and lfs-tap to allow an [org.apache.hadoop.fs.PathFilter](http://hadoop.apache.org/common/docs/r0.20.205.0/api/org/apache/hadoop/fs/PathFilter.html) to be passed through (eventually) to glob-hfs and then [cascading.tap.GlobHfs](http://www.cascading.org/1.2/javadoc/cascading/tap/GlobHfs.html#GlobHfs%28cascading.scheme.Scheme, java.lang.String, org.apache.hadoop.fs.PathFilter%29). This adds some more flexibility in selecting source paths.
