### PR TITLE
Rough patch for TextDelimited support so I can skip-headers in files

### DIFF
--- a/src/clj/cascalog/api.clj
+++ b/src/clj/cascalog/api.clj
@@ -41,6 +41,7 @@
 (defalias lfs-tap tap/lfs-tap)
 (defalias sequence-file w/sequence-file)
 (defalias text-line w/text-line)
+(defalias text-delimited w/text-delimited)
 
 (defn hfs-textline
   "Creates a tap on HDFS using textline format. Different filesystems
@@ -64,10 +65,51 @@
 
    See http://www.cascading.org/javadoc/cascading/tap/Lfs.html and
    http://www.cascading.org/javadoc/cascading/scheme/TextLine.html"
-  [path & opts]
+  [path delimiter & opts]
   (let [scheme (->> (:outfields (apply array-map opts) Fields/ALL)
                     (w/text-line ["line"]))]
     (apply tap/lfs-tap scheme path opts)))
+
+
+(defn hfs-textdelimited
+  "Creates a tap on HDFS using textdelimited format. Different filesystems
+   can be selected by using different prefixes for `path`.
+
+  Supports keyword option for `:outfields`.
+  `:delimiter` for the delimiter to split on
+  `:skip-header` if true will skip the first line
+  See `cascalog.tap/hfs-tap` for more keyword arguments.
+
+   See http://www.cascading.org/javadoc/cascading/tap/Hfs.html and
+   http://www.cascading.org/javadoc/cascading/scheme/TextLine.html"
+  [path & opts]
+  (let [opts-map (apply array-map opts)
+        delimiter (:delimiter opts-map ",")
+        skip-header (:skip-header opts-map false)
+        scheme (->> (:outfields opts-map Fields/ALL)
+                       (w/text-delimited Fields/ALL delimiter skip-header))]
+    (apply tap/hfs-tap scheme path opts)))
+
+(defn lfs-textdelimited
+  "Creates a tap on the local filesystem using a text delimted format.
+  Such as csv or tsv
+
+  Supports keyword option for `:outfields`.
+  `:delimiter` for the delimiter to split on
+  `:skip-header` if true will skip the first line
+  See `cascalog.tap/lfs-tap` for more keyword arguments.
+
+   See http://www.cascading.org/javadoc/cascading/tap/Lfs.html and
+   http://www.cascading.org/javadoc/cascading/scheme/TextLine.html"
+  [path & opts]
+  (let [opts-map (apply array-map opts)
+        delimiter (:delimiter opts-map ",")
+        skip-header (:skip-header opts-map false)
+        scheme (->> (:outfields opts-map Fields/ALL)
+                       (w/text-delimited Fields/ALL delimiter skip-header))]
+       (apply tap/lfs-tap scheme path opts)))
+
+
 
 (defn hfs-seqfile
   "Creates a tap on HDFS using sequence file format. Different

--- a/src/clj/cascalog/workflow.clj
+++ b/src/clj/cascalog/workflow.clj
@@ -27,7 +27,7 @@
            [java.io File]
            [java.util ArrayList]
            [cascading.tuple Tuple TupleEntry Fields]
-           [cascading.scheme Scheme TextLine SequenceFile]
+           [cascading.scheme Scheme TextLine SequenceFile TextDelimited]
            [cascading.tap Hfs Lfs GlobHfs Tap TemplateTap SinkMode]
            [cascading.tuple TupleEntryCollector]
            [cascading.flow Flow FlowConnector]
@@ -468,6 +468,14 @@
      (TextLine. (fields field-names) (fields field-names)))
   ([source-fields sink-fields]
      (TextLine. (fields source-fields) (fields sink-fields))))
+
+(defn text-delimited
+  ([field-names delimiter]
+     (TextDelimited. (fields field-names) delimiter))
+  ([source-fields delimiter skip-header]
+     (TextDelimited. (fields source-fields) skip-header delimiter))
+  ([source-fields delimiter skip-header junk]
+     (TextDelimited. (fields source-fields) skip-header delimiter)))
 
 (defn sequence-file [field-names]
   (SequenceFile. (fields field-names)))


### PR DESCRIPTION
Rough implemention for TextDelimited Scheme support. 
Not sure why I needed the 4 args versions, but was receiving calls to it.

Usage:

``` clojure
  (defn name-age-data [dir]
    (let [source (lfs-textdelimited dir :delimiter "," :skip-header true)]
      (<- [?name ?age]
        (source ?name ?age))))

  (?<- (stdout)
    [?name ?age]
    ((name-age-data "/tmp/name_age.csv") ?name ?age)
    (< ?age 25))
```

Please make a better version
