### PR TITLE
close TupleEntryIterator in StdoutTap

### DIFF
--- a/src/jvm/cascalog/StdoutTap.java
+++ b/src/jvm/cascalog/StdoutTap.java
@@ -68,6 +68,10 @@ public class StdoutTap extends Lfs implements FlowListener {
             System.out.println("-----------------------");
         } catch (IOException ioe) {
             throw new RuntimeException(ioe);
+        } finally {
+            if (it != null) {
+                it.close();
+            }
         }
     }
 


### PR DESCRIPTION
Might not matter for the real use cases but a TupleEntryIterator should be closed at the end no matter what.
