### PR TITLE
fixes Leiningen complaint on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 
 language: clojure
 lein: lein2
-script: lein2 compile, midje
+script: lein2 do compile, midje
 branches:
   only:
     - develop


### PR DESCRIPTION
Travis CI seems to have updated Leiningen to [2.0.0-preview7](https://groups.google.com/d/topic/clojure/FMoYnqhC4i4/discussion) which comes with a slightly changed way to execute two or more goals. see `lein help do`
