### PR TITLE
cascalog.io/with-fs-tmp's root dir now is configurable

### DIFF
--- a/src/clj/cascalog/io.clj
+++ b/src/clj/cascalog/io.clj
@@ -98,15 +98,18 @@ Raise an exception if any deletion fails unless silently is true."
    (for [t paths]
      (.delete fs (hadoop/path t) true))))
 
+(def ^{:doc "Use this variable as key in JobConf if you want to override the root of temporary paths. See with-fs-tmp"}
+  tmp-dir-property "cascalog.tmpdir")
+
 (defmacro with-fs-tmp
   "Generates unique, temporary path names as subfolders of <root>/cascalog_reserved.
 
   <root> by default will be '/tmp', but you can configure it via the JobConf property
-  'cascalog.tmpdir'."
+  `cascalog.io/tmp-dir-property`."
   [[fs-sym & tmp-syms] & body]
   (let [tmp-root (gensym "tmp-root")]
    `(let [~fs-sym (hadoop/filesystem)
-          ~tmp-root (str (get (conf/project-conf) "cascalog.tmpdir" "/tmp")
+          ~tmp-root (str (get (conf/project-conf) tmp-dir-property "/tmp")
                          "/cascalog_reserved")
           ~@(mapcat (fn [t]
                       [t `(str ~tmp-root "/" (u/uuid))])

--- a/test/cascalog/io_test.clj
+++ b/test/cascalog/io_test.clj
@@ -8,7 +8,7 @@
  (is (.startsWith (with-fs-tmp [_ foo]
                     foo)
                   "/tmp/cascalog_reserved/"))
- (is (.startsWith (api/with-job-conf {"cascalog.tmpdir"
+ (is (.startsWith (api/with-job-conf {tmp-dir-property
                                       ;; deliberately using lein's build directory
                                       "target/bar"}
                     (with-fs-tmp [_ foo]


### PR DESCRIPTION
I'm getting back to https://groups.google.com/d/topic/cascalog-user/523iptcITWM/discussion.

Please consider this pull request an attempt. Certainly there are things to be discussed here:
- the general approach (to use jobconf to configure the root directory for "cascalog_reserved")
- the name of the configuration variable: "cascalog.tmpdir"
- whether it is reasonable to consider "cascalog_reserved" a reserved place where Cascalog dwells and just provide a way to configure under which directory it is hooked

Looking forward to getting feedbak on this!

From (doc 'cascalog.io/with-ts-tmp'):

with-fs-tmp generates unique, temporary path names as subfolders of
<root>/cascalog_reserved. <root> by default will be '/tmp', but you
can configure it via the JobConf property 'cascalog.tmpdir'.
