### PR TITLE
Bump cascading to 2.0.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def shared
   '[[org.clojure/tools.macro "0.1.1"]
-    [cascading/cascading-hadoop "2.0.0"
+    [cascading/cascading-hadoop "2.0.3"
      :exclusions [org.codehaus.janino/janino
                   org.apache.hadoop/hadoop-core]]
     [org.clojure/tools.macro "0.1.1"]

--- a/src/clj/cascalog/testing.clj
+++ b/src/clj/cascalog/testing.clj
@@ -23,8 +23,10 @@
            [java.io File]))
 
 (defn roundtrip [obj]
-  (HadoopUtil/deserializeBase64
-   (HadoopUtil/serializeBase64 obj)))
+  (let [conf (hadoop/job-conf (conf/project-conf))]
+    (HadoopUtil/deserializeBase64
+      (HadoopUtil/serializeBase64 obj conf true)
+      conf (class obj) true)))
 
 (defn invoke-filter [fil coll]
   (let [fil     (roundtrip fil)


### PR DESCRIPTION
There's a small method signature change between cascading 2.0.0 and 2.0.3.

At Rapleaf, we're using the most recent cascading wip because it has some bug fixes.  This method signature change is the only thing preventing cascalog from being compatible.  So the version bump would be really helpful.
