### PR TITLE
hfs-tap: Added link to a scheme class to clarify how to use it.

### DIFF
--- a/src/clj/cascalog/tap.clj
+++ b/src/clj/cascalog/tap.clj
@@ -48,8 +48,10 @@
   used as a sink.
 
   `:templatefields` - When pattern is supplied via :sink-template, this option allows a
-  subset of output fields to be used in the naming scheme."
-  [scheme path-or-file & {:keys [sinkmode sinkparts sink-template
+  subset of output fields to be used in the naming scheme.
+
+  See f.ex. the http://docs.cascading.org/cascading/2.0/javadoc/cascading/scheme/local/TextDelimited.html scheme."
+  [^cascading.scheme.Scheme scheme path-or-file & {:keys [sinkmode sinkparts sink-template
                                  source-pattern templatefields]
                           :or {templatefields Fields/ALL}}]
   (-> scheme


### PR DESCRIPTION
It was pretty unclear to me from the doc or source code what a "scheme"
is (and the Scheme class itself is too generic and abstract), providing
link to a concrete, directly usable subclass might help.
Specifying the type of the parameter help to self-document the code too.
