### PR TITLE
add message to show the difference between needed-vars and project-field...

### DIFF
--- a/src/clj/cascalog/rules.clj
+++ b/src/clj/cascalog/rules.clj
@@ -395,7 +395,9 @@
     (debug-print "build gen:" my-needed project-fields pred)
     (if (and forceproject (not= project-fields needed-vars))
       (throw-runtime (str "Only able to build to " project-fields
-                          " but need " needed-vars))
+                          " but need " needed-vars
+                          ". Missing " (vec (clojure.set/difference (set needed-vars)
+                                                                    (set project-fields)))))
       (merge newgen
              {:pipe ((mk-projection-assembly forceproject
                                              project-fields

--- a/test/cascalog/api_secondary_test.clj
+++ b/test/cascalog/api_secondary_test.clj
@@ -60,6 +60,14 @@
                    [(-> [[age "?p" "?a"] [#'inc "?a" :> "?a2"]]
                         (conj [gender "?p" "!!g"]))]))))
 
+(deftest test-fail-to-construct
+  (let [foos [["alice"] ["bob"]]]
+    (is (thrown-with-msg? RuntimeException #"Missing.*?bar"
+          (test?- []
+                  (apply construct
+                         ["?foo" "?bar"]
+                         [(-> [[foos "?foo"]])]))))))
+
 (deftest test-cascalog-tap-source
   (io/with-log-level :fatal
     (let [num [[1]]


### PR DESCRIPTION
Hi,

Paul (@Quantisan) and I added the changes to make it easier to see when we'd missed or misnamed fields. Rather than just printing the 2 lists, we also show the difference between them.
