### PR TITLE
wrap facts in deftest, clean -core tests

### DIFF
--- a/cascalog-checkpoint/project.clj
+++ b/cascalog-checkpoint/project.clj
@@ -6,11 +6,7 @@
   :dependencies [[cascalog/cascalog-core "1.10.1-SNAPSHOT"]
                  [jackknife "0.1.2"]
                  [hadoop-util "0.2.8"]]
-  :plugins [[lein-midje "3.0-alpha4"]]
   :profiles {:1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.0-RC1"]]}
              :dev {:dependencies
-                   [[org.apache.hadoop/hadoop-core "1.0.3"]
-                    [midje "1.5-alpha10"]
-                    [midje-cascalog "0.4.0"
-                     :exclusions [org.clojure/clojure]]]}})
+                   [[org.apache.hadoop/hadoop-core "1.0.3"]]}})

--- a/cascalog-checkpoint/test/cascalog/checkpoint_test.clj
+++ b/cascalog-checkpoint/test/cascalog/checkpoint_test.clj
@@ -1,10 +1,10 @@
 (ns cascalog.checkpoint-test
   (:use cascalog.checkpoint
-        midje.sweet))
+        clojure.test))
 
 (def sprint identity)
 
-(defn run-test! []
+(deftest workflow-test
   (workflow ["/tmp/lalala"]
             aaa ([] (sprint "aaa")
                    (sprint "aaa")

--- a/cascalog-core/test/cascalog/bridge_test.clj
+++ b/cascalog-core/test/cascalog/bridge_test.clj
@@ -1,5 +1,6 @@
 (ns cascalog.bridge-test
-  (:use midje.sweet)
+  (:use midje.sweet
+        clojure.test)
   (:require [cascalog.workflow :as w]
             [cascalog.testing :as t]
             [cascalog.util :as u])
@@ -8,8 +9,9 @@
            [cascalog ClojureFilter ClojureMap ClojureMapcat
             ClojureAggregator Util]))
 
-(fact "ns-fn-name-pair should produce a pair of strings."
-  (w/ns-fn-name-pair #'str) => ["clojure.core" "str"])
+(deftest ns-fn-name-pair-test
+  (fact "ns-fn-name-pair should produce a pair of strings."
+    (w/ns-fn-name-pair #'str) => ["clojure.core" "str"])) 
 
 (def obj-array-class
   (Class/forName "[Ljava.lang.Object;"))
@@ -32,71 +34,77 @@
   input is an instance of the supplied class."
   [^Class expected]
   (chatty-checker
-   [actual]
-   (instance? expected actual)))
+    [actual]
+    (instance? expected actual)))
 
-(tabular
- (fact
-   "fn-spec should propery resolve a var (or vector of var and
-   arguments) into an object array of namespace, function name
-   and (optionally) arguments."
-   (let [spec (w/fn-spec ?input)]
-     spec       => (is-type obj-array-class)
-     (seq spec) => ?result-vec))
- ?input       ?result-vec
- #'plus-one   ["cascalog.bridge-test" "plus-one"]
- [#'plus-n 3] ["cascalog.bridge-test" "plus-n" 3])
+(deftest fn-spec-test
+  (tabular
+    (fact
+      "fn-spec should propery resolve a var (or vector of var and
+      arguments) into an object array of namespace, function name
+      and (optionally) arguments."
+      (let [spec (w/fn-spec ?input)]
+        spec       => (is-type obj-array-class)
+        (seq spec) => ?result-vec))
+    ?input       ?result-vec
+    #'plus-one   ["cascalog.bridge-test" "plus-one"]
+    [#'plus-n 3] ["cascalog.bridge-test" "plus-n" 3])) 
 
+(deftest bootFn-test
+  (tabular
+    (fact "bootFn tests, simple and higher order."
+      (let [spec (into-array Object ?spec)
+            f    (Util/bootFn spec)]
+        (f 1) => ?result))
+    ?spec                               ?result
+    ["cascalog.bridge-test" "plus-one"] [2]
+    ["cascalog.bridge-test" "plus-n" 3] [4])) 
 
-(tabular
- (fact "bootFn tests, simple and higher order."
-   (let [spec (into-array Object ?spec)
-         f    (Util/bootFn spec)]
-     (f 1) => ?result))
- ?spec                               ?result
- ["cascalog.bridge-test" "plus-one"] [2]
- ["cascalog.bridge-test" "plus-n" 3] [4])
+(deftest Fields-test
+  (facts "Fields tests."
+    (let [f1 (w/fields "foo")
+          f2 (w/fields ["foo" "bar"])]
+      (facts "Single fields should resolve properly."
+        f1       => #(instance? Fields %)
+        (seq f1) => ["foo"])
 
-(facts "Fields tests."
-  (let [f1 (w/fields "foo")
-        f2 (w/fields ["foo" "bar"])]
-    (facts "Single fields should resolve properly."
-      f1       => #(instance? Fields %)
-      (seq f1) => ["foo"])
+      (facts "Double fields should resolve properly."
+        f2       => #(instance? Fields %)
+        (seq f2) => ["foo" "bar"])))) 
 
-    (facts "Double fields should resolve properly."
-      f2       => #(instance? Fields %)
-      (seq f2) => ["foo" "bar"])))
+(deftest pipe-test
+  (tabular 
+    (fact "Pipe testing."
+      ?pipe => #(instance? Pipe %)
+      (.getName ?pipe) => ?check)
+    ?pipe           ?check
+    (w/pipe)        #(= 36 (.length %))
+    (w/pipe "name") "name")) 
 
-(tabular 
- (fact "Pipe testing."
-   ?pipe => #(instance? Pipe %)
-   (.getName ?pipe) => ?check)
- ?pipe           ?check
- (w/pipe)        #(= 36 (.length %))
- (w/pipe "name") "name")
+(deftest ClojureFilter-test
+  (fact "Clojure Filter test."
+    (let [fil (ClojureFilter. (w/fn-spec #'odd?) false)]
+      (t/invoke-filter fil [1]) => false
+      (t/invoke-filter fil [2]) => true))) 
 
-(fact "Clojure Filter test."
-  (let [fil (ClojureFilter. (w/fn-spec #'odd?) false)]
-    (t/invoke-filter fil [1]) => false
-    (t/invoke-filter fil [2]) => true))
+(deftest ClojureMap-single-field-test
+  (tabular
+    (fact "ClojureMap test, single field."
+      (t/invoke-function ?clj-map [1]) => [[2]])
+    ?clj-map
+    (ClojureMap. (w/fields "num")
+                 (w/fn-spec #'inc-wrapped)
+                 false)
+    (ClojureMap. (w/fields "num")
+                 (w/fn-spec #'inc)
+                 false))) 
 
-(tabular
- (fact "ClojureMap test, single field."
-   (t/invoke-function ?clj-map [1]) => [[2]])
- ?clj-map
- (ClojureMap. (w/fields "num")
-              (w/fn-spec #'inc-wrapped)
-              false)
- (ClojureMap. (w/fields "num")
-              (w/fn-spec #'inc)
-              false))
-
-(facts "ClojureMap test, multiple fields."
-  (let [m (ClojureMap. (w/fields ["num1" "num2"])
-                       (w/fn-spec #'inc-both)
-                       false)]
-    (t/invoke-function m [1 2]) => [[2 3]]))
+(deftest ClojureMap-multiple-fields-test
+  (facts "ClojureMap test, multiple fields."
+    (let [m (ClojureMap. (w/fields ["num1" "num2"])
+                         (w/fn-spec #'inc-both)
+                         false)]
+      (t/invoke-function m [1 2]) => [[2 3]]))) 
 
 (defn iterate-inc-wrapped [num]
   (list [(+ num 1)]
@@ -108,24 +116,26 @@
         (+ num 2)
         (+ num 3)))
 
-(tabular
- (fact "ClojureMapCat test, single field."
-   (t/invoke-function ?clj-mapcat [1]) => [[2] [3] [4]])
- ?clj-mapcat
- (ClojureMapcat. (w/fields "num")
-                 (w/fn-spec #'iterate-inc-wrapped)
-                 false)
- (ClojureMapcat. (w/fields "num")
-                 (w/fn-spec #'iterate-inc)
-                 false))
+(deftest ClojureMapCat-single-field-test
+  (tabular
+    (fact "ClojureMapCat test, single field."
+      (t/invoke-function ?clj-mapcat [1]) => [[2] [3] [4]])
+    ?clj-mapcat
+    (ClojureMapcat. (w/fields "num")
+                    (w/fn-spec #'iterate-inc-wrapped)
+                    false)
+    (ClojureMapcat. (w/fields "num")
+                    (w/fn-spec #'iterate-inc)
+                    false))) 
 
 (defn sum
   ([] 0)
   ([mem v] (+ mem v))
   ([mem] [mem]))
 
-(fact "ClojureAggregator test."
-  (let [a (ClojureAggregator. (w/fields "sum")
-                              (w/fn-spec #'sum)
-                              false)]
-    (t/invoke-aggregator a [[1] [2] [3]]) => [[6]]))
+(deftest ClojureAggregator-test
+  (fact "ClojureAggregator test."
+    (let [a (ClojureAggregator. (w/fields "sum")
+                                (w/fn-spec #'sum)
+                                false)]
+      (t/invoke-aggregator a [[1] [2] [3]]) => [[6]]))) 

--- a/cascalog-core/test/cascalog/conf_test.clj
+++ b/cascalog-core/test/cascalog/conf_test.clj
@@ -1,5 +1,6 @@
 (ns cascalog.conf-test
   (:use cascalog.api
+        clojure.test
         [midje sweet cascalog])
   (:require [clojure.string :as s]
             [cascalog.conf :as conf]
@@ -13,15 +14,15 @@
 (def defaults
   (comma u/default-serializations))
 
-(fact "test JobConf bindings."
+(deftest with-job-conf-test
   (with-job-conf {"key" "val"}
     (fact "The first binding level should set the JobConf equal to the
       supplied conf map."
       conf/*JOB-CONF* => {"key" "val"}))
   
   (with-job-conf {"key" ["val1" "val2"]
-                  "other-key" "other-val"}
-    (fact "Vectors of strings will be joined w/ commas. (This binding
+                  "other-key" "other-val"} 
+    (fact "Vectors of strings will be joined w/ commas. This binding
       level knocks out the previous, as the keys are identical."
       conf/*JOB-CONF* => {"key" "val1,val2"
                           "other-key" "other-val"})
@@ -29,28 +30,27 @@
     (with-job-conf {"key" ["val3"]}
       (fact "other-key from above should be preserved."
         conf/*JOB-CONF* => {"key" "val3"
-                            "other-key" "other-val"})))
+                            "other-key" "other-val"}))) 
   
   (with-job-conf {"io.serializations" "java.lang.String"}
     conf/*JOB-CONF* => {"io.serializations" "java.lang.String"}
     (fact
       "Calling project-merge on the JobConf will prepend default
-       serializations onto the supplied list of serializations."
+      serializations onto the supplied list of serializations."
       (u/project-merge conf/*JOB-CONF*) => {"io.serializations"
                                             (comma [defaults "java.lang.String"])})
-
     (with-serializations [String]
       (fact
         "You can specify serialiations using the `with-serializations`
-      form. This works w/ class objects or strings. Without
-      project-merge, the *JOB-CONF* variable is unaffected. (Note that
-      classes are resolved properly.)"
+        form. This works w/ class objects or strings. Without
+        project-merge, the *JOB-CONF* variable is unaffected. (Note that
+        classes are resolved properly.)"
         conf/*JOB-CONF* => {"io.serializations" "java.lang.String"})
 
       (fact "Again, project-merging with w/ Class objects, vs Strings."
         (u/project-merge conf/*JOB-CONF*) => {"io.serializations"
-                                              (comma [defaults "java.lang.String"])})))
-  
+                                              (comma [defaults "java.lang.String"])}))) 
+
   (with-serializations [String]
     (with-job-conf {"io.serializations" "java.lang.String,SomeSerialization"}
       (fact "with-serializations nests properly with with-job-conf."
@@ -59,34 +59,36 @@
                                                       "java.lang.String"
                                                       "SomeSerialization"])}))))
 
-(facts "Tests of various aspects of Kryo serialization."
-  (with-job-conf
-    {"cascading.kryo.serializations" "java.util.DoesntExist"
-     "cascading.kryo.skip.missing" true
-     "cascading.kryo.accept.all" true}
-    (let [cal-tuple [[(java.util.GregorianCalendar.)]]]
-      (fact?<- cal-tuple
-               [?a]
-               (cal-tuple ?a)) ))
+(deftest kryo-properties-test
+  (facts "Tests of various aspects of Kryo serialization."
+    (with-job-conf
+      {"cascading.kryo.serializations" "java.util.DoesntExist"
+       "cascading.kryo.skip.missing" true
+       "cascading.kryo.accept.all" true}
+      (let [cal-tuple [[(java.util.GregorianCalendar.)]]]
+        (fact?<- cal-tuple
+                 [?a]
+                 (cal-tuple ?a)) ))
 
-  (with-job-conf
-    {"cascading.kryo.accept.all" false}
-    (let [cal-tuple [[(java.util.GregorianCalendar.)]]]
-      (fact
-        "Attempting to serialize an unregistered object when
-      accept.all is set to false should throw a flow exception."
-        (??<- [?a] (cal-tuple ?a))) => (throws PlannerException))))
+    (with-job-conf
+      {"cascading.kryo.accept.all" false}
+      (let [cal-tuple [[(java.util.GregorianCalendar.)]]]
+        (fact
+          "Attempting to serialize an unregistered object when
+          accept.all is set to false should throw a flow exception."
+          (??<- [?a] (cal-tuple ?a))) => (throws PlannerException))))) 
 
-(tabular
- (fact "Test of various comparators."
-   (let [comp (DefaultComparator.)]
-     (.compare comp ?left ?right) => ?expected))
-  ?left     ?right       ?expected
-  0         0            0
-  1         1            0
-  1         1M           0
-  1M        1            0
-  2M        1            1
-  (Long. 4) (Integer. 3) 1
-  (Long. 3) (Integer. 4) -1
-  1         2M           -1)
+(deftest comparator-test
+  (tabular
+    (fact "Test of various comparators."
+      (let [comp (DefaultComparator.)]
+        (.compare comp ?left ?right) => ?expected))
+    ?left     ?right       ?expected
+    0         0            0
+    1         1            0
+    1         1M           0
+    1M        1            0
+    2M        1            1
+    (Long. 4) (Integer. 3) 1
+    (Long. 3) (Integer. 4) -1
+    1         2M           -1)) 

--- a/cascalog-core/test/cascalog/defops_test.clj
+++ b/cascalog-core/test/cascalog/defops_test.clj
@@ -49,17 +49,18 @@
      ident-meta
      ident-both)))
 
-(facts "Metadata testing."
-  "Both function and var should contain custom metadata."
-  (meta ident-stateful) => (contains {:great-meta "yes!"})
-  (meta #'ident-stateful) => (contains {:great-meta "yes!"})
+(deftest metadata-test
+  (facts "Metadata testing."
+    "Both function and var should contain custom metadata."
+    (meta ident-stateful) => (contains {:great-meta "yes!"})
+    (meta #'ident-stateful) => (contains {:great-meta "yes!"})
 
-  "Both function and var should contain docstrings."
-  (meta ident-doc) => (contains {:doc "Identity operation."})
-  (meta #'ident-doc) => (contains {:doc "Identity operation."})
+    "Both function and var should contain docstrings."
+    (meta ident-doc) => (contains {:doc "Identity operation."})
+    (meta #'ident-doc) => (contains {:doc "Identity operation."})
 
-  "ident-meta shouldn't have a docstring in its metadata."
-  (meta #'ident-meta) =not=> (contains {:doc anything}))
+    "ident-meta shouldn't have a docstring in its metadata."
+    (meta #'ident-meta) =not=> (contains {:doc anything}))) 
 
 
 (defn five->two [a b c d e]

--- a/cascalog-core/test/cascalog/graph_test.clj
+++ b/cascalog-core/test/cascalog/graph_test.clj
@@ -1,5 +1,6 @@
 (ns cascalog.graph-test
   (:use cascalog.graph
+        clojure.test
         midje.sweet))
 
 (defn just-nodevals [vals]
@@ -8,7 +9,7 @@
      [n]
      (check (map get-value (get-outbound-nodes n))))))
 
-(fact "Test adding nodes and edges."
+(deftest nodes-edges-test
   (let [g (mk-graph)
         n1 (create-node g "AAA")
         n2 (create-node g "BBB")
@@ -24,9 +25,9 @@
       n1 => (just-nodevals ["BBB" "CCC"])
       n2 => (just-nodevals [])
       n3 => (just-nodevals ["DDD"])
-      n4 => (just-nodevals []))))
+      n4 => (just-nodevals [])))) 
 
-(fact "test extra data"
+(deftest extra-data-test
   (let [g  (mk-graph)
         n1 (create-node g "n1")
         n2 (create-node g "n2")
@@ -46,4 +47,4 @@
     (facts "More checks."
       (get-extra-data n2 :b) => 4
       (-> (first (get-outbound-edges n1))
-          (get-extra-data :a)) => 101)))
+          (get-extra-data :a)) => 101))) 

--- a/cascalog-core/test/cascalog/tap_test.clj
+++ b/cascalog-core/test/cascalog/tap_test.clj
@@ -1,6 +1,7 @@
 (ns cascalog.tap-test
   (:use cascalog.tap
         [midje sweet cascalog]
+        clojure.test
         cascalog.testing)
   (:require [cascalog.io :as io]
             [cascalog.api :as api]
@@ -35,56 +36,62 @@
 (def lfs-test-source (test-tap-builder lfs-tap tap-source))
 (def lfs-test-sink (test-tap-builder lfs-tap tap-sink))
 
-(tabular
- (facts "api outfields testing."
-   (-> (apply api/hfs-textline "path" ?opts)
-       (tap-sink)
-       (.getSinkFields)) => ?fields)
- ?fields                ?opts
- (w/fields Fields/ALL)  []
- (w/fields ["?a"])      [:outfields ["?a"]]
- (w/fields ["?a" "!b"]) [:outfields ["?a" "!b"]])
+(deftest api-outfields-test
+  (tabular
+    (facts "api outfields testing."
+      (-> (apply api/hfs-textline "path" ?opts)
+          (tap-sink)
+          (.getSinkFields)) => ?fields)
+    ?fields                ?opts
+    (w/fields Fields/ALL)  []
+    (w/fields ["?a"])      [:outfields ["?a"]]
+    (w/fields ["?a" "!b"]) [:outfields ["?a" "!b"]])) 
 
-(tabular
- (fact "Type testing on the various taps."
-   ?tap => (fn [x] (instance? ?type x)))
- ?type        ?tap
- TemplateTap (hfs-test-sink :sink-template "%s/")
- GlobHfs     (hfs-test-source :source-pattern "%s/")
- Hfs         (hfs-test-sink :source-pattern "%s/")
- Hfs         (hfs-test-source)
- Lfs         (lfs-test-source))
+(deftest taps-type-test
+  (tabular
+    (fact "Type testing on the various taps."
+      ?tap => (fn [x] (instance? ?type x)))
+    ?type        ?tap
+    TemplateTap (hfs-test-sink :sink-template "%s/")
+    GlobHfs     (hfs-test-source :source-pattern "%s/")
+    Hfs         (hfs-test-sink :source-pattern "%s/")
+    Hfs         (hfs-test-source)
+    Lfs         (lfs-test-source))) 
 
-(fact "SinkMode testing."
-  (hfs-test-sink) => (memfn isKeep)
-  (hfs-test-sink :sinkmode :keep) => (memfn isKeep)
-  (hfs-test-sink :sinkmode :update) => (memfn isUpdate)
-  (hfs-test-sink :sinkmode :replace) => (memfn isReplace))
+(deftest sinkmode-test
+  (fact "SinkMode testing."
+    (hfs-test-sink) => (memfn isKeep)
+    (hfs-test-sink :sinkmode :keep) => (memfn isKeep)
+    (hfs-test-sink :sinkmode :update) => (memfn isUpdate)
+    (hfs-test-sink :sinkmode :replace) => (memfn isReplace))) 
 
-(tabular
- (fact ":sinkparts keyword should tune sink settings."
-   (-> (apply ?func ?opts)
-       (get-scheme)
-       (.getNumSinkParts)) => ?result)
- ?result ?func         ?opts
- 3       hfs-test-sink [:sinkparts 3]
- 3       lfs-test-sink [:sinkparts 3]
- 0       hfs-test-sink []
- 0       lfs-test-sink [])
+(deftest sinkparts-test
+  (tabular
+    (fact ":sinkparts keyword should tune sink settings."
+      (-> (apply ?func ?opts)
+          (get-scheme)
+          (.getNumSinkParts)) => ?result)
+    ?result ?func         ?opts
+    3       hfs-test-sink [:sinkparts 3]
+    3       lfs-test-sink [:sinkparts 3]
+    0       hfs-test-sink []
+    0       lfs-test-sink [])) 
 
-(fact
-  ":sink-template option should set path template on cascading tap."
-  (.getPathTemplate (hfs-test-sink :sink-template "%s/"))) => "%s/"
+(deftest sink-template-test
+  (fact
+    ":sink-template option should set path template on cascading tap."
+    (.getPathTemplate (hfs-test-sink :sink-template "%s/")) => "%s/")) 
 
-(fact
-  "Test executing tuples into a template tap and sourcing them back
-  out with a source pattern."
-  (io/with-log-level :fatal
-    (io/with-fs-tmp [_ tmp]
-      (let [tuples [[1 2] [2 3] [4 5]]
-            temp-tap (api/hfs-seqfile (str tmp "/")
-                                      :sink-template "%s/"
-                                      :source-pattern "{1,2}/*")]
-        temp-tap
-        (api/?<- temp-tap [?a ?b] (tuples ?a ?b))
-        temp-tap => (produces [[1 2] [2 3]])))))
+(deftest template-tap-test
+  (fact
+    "Test executing tuples into a template tap and sourcing them back
+    out with a source pattern."
+    (io/with-log-level :fatal
+      (io/with-fs-tmp [_ tmp]
+        (let [tuples [[1 2] [2 3] [4 5]]
+              temp-tap (api/hfs-seqfile (str tmp "/")
+                                        :sink-template "%s/"
+                                        :source-pattern "{1,2}/*")]
+          temp-tap
+          (api/?<- temp-tap [?a ?b] (tuples ?a ?b))
+          temp-tap => (produces [[1 2] [2 3]])))))) 

--- a/cascalog-core/test/cascalog/util_test.clj
+++ b/cascalog-core/test/cascalog/util_test.clj
@@ -1,5 +1,6 @@
 (ns cascalog.util-test
   (:use cascalog.util
+        clojure.test
         midje.sweet))
 
 (tabular
@@ -10,27 +11,30 @@
  [1 2 3]     [[1 2] [1 3] [2 3]]
  [1 :a :a 2] [[1 :a] [1 :a] [1 2] [:a :a] [:a 2] [:a 2]])
 
-(facts "count= tests."
-  (count= [1] []) => false
-  
-  (count= [1] [1] [3]) => true 
-  (count= [1 2] [4 3]) => true 
+(deftest count=-test
+  (facts "count= tests."
+    (count= [1] []) => false
 
-  (not-count= [1] []) => true 
-  (not-count= [1 2] [3 4] []) => true 
-  (not-count= [1] [1]) => false
-  (not-count= [1 2] [4 3]) => false)
+    (count= [1] [1] [3]) => true 
+    (count= [1 2] [4 3]) => true 
 
-(fact "Conf-merging test."
-  (let [m1 {"key" "foo"
-            "key2" ["bar" "baz"]}
-        m2 {"key" ["cake" "salad"]}]
-    (conf-merge m1)    => {"key" "foo", "key2" "bar,baz"}
-    (conf-merge m1 m2) => {"key" "cake,salad", "key2" "bar,baz"}))
+    (not-count= [1] []) => true 
+    (not-count= [1 2] [3 4] []) => true 
+    (not-count= [1] [1]) => false
+    (not-count= [1 2] [4 3]) => false)) 
 
-(fact "Stringify test."
-  (stringify-keys
-   {:key "val" "key2" "val2"}) => {"key" "val" "key2" "val2"})
+(deftest conf-merge-test
+  (fact "Conf-merging test."
+    (let [m1 {"key" "foo"
+              "key2" ["bar" "baz"]}
+          m2 {"key" ["cake" "salad"]}]
+      (conf-merge m1)    => {"key" "foo", "key2" "bar,baz"}
+      (conf-merge m1 m2) => {"key" "cake,salad", "key2" "bar,baz"}))) 
+
+(deftest stringify-test
+  (fact "Stringify test."
+    (stringify-keys
+      {:key "val" "key2" "val2"}) => {"key" "val" "key2" "val2"})) 
 
 (future-fact
  "Test that stringify-keys can handle clashes between,

--- a/cascalog-math/project.clj
+++ b/cascalog-math/project.clj
@@ -4,11 +4,9 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :repositories {"conjars.org" "http://conjars.org/repo"}
   :dependencies [[cascalog/cascalog-core "1.10.1-SNAPSHOT"]]
-  :plugins [[lein-midje "3.0-alpha4"]]
   :profiles {:1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.0-RC1"]]}
              :dev {:dependencies
-                   [[org.apache.hadoop/hadoop-core "1.0.3"]
-                    [midje "1.5-alpha10"]
+                   [[org.apache.hadoop/hadoop-core "1.0.3"]                    
                     [midje-cascalog "0.4.0"
                      :exclusions [org.clojure/clojure]]]}})

--- a/cascalog-math/test/cascalog/math/stats_test.clj
+++ b/cascalog-math/test/cascalog/math/stats_test.clj
@@ -1,5 +1,7 @@
 (ns cascalog.math.stats-test
   (:use [cascalog.math.stats]
+        [clojure.test]
         [midje sweet cascalog]))
 
+;; TODO add test
 (fact?<- [[1]] [?x] ([[1]] ?x))

--- a/midje-cascalog/test/midje/cascalog_test.clj
+++ b/midje-cascalog/test/midje/cascalog_test.clj
@@ -6,6 +6,8 @@
         [clojure.math.combinatorics :only [permutations]])
   (:require [cascalog.ops :as c]))
 
+; TODO failing, update tests
+
 ;; ## Testing Battery
 
 (defn whoop [x] [[x]])


### PR DESCRIPTION
wrapping facts in deftest to work with `(clojure.test/run-tests)` in repl

elephantdb, lzo, and checkpoint are failing so I didn't touch them for this pull
