### PR TITLE
Midje tabular

### DIFF
--- a/midje-cascalog/project.clj
+++ b/midje-cascalog/project.clj
@@ -3,10 +3,9 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :repositories {"conjars.org" "http://conjars.org/repo"}
-  :dependencies [[cascalog/cascalog-core "1.10.1-SNAPSHOT"]
-                 [midje "1.3.0"]]
-   :plugins [[lein-midje "2.0.4"]]
+  :dependencies [[midje "1.5-beta1"]]
+  :plugins [[lein-midje "3.0-beta1"]]
   :profiles {:1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.0-RC1"]]}
-             :dev {:dependencies
-                   [[org.apache.hadoop/hadoop-core "1.0.3"]]}})
+             :dev {:dependencies [[org.apache.hadoop/hadoop-core "1.0.3"]]}
+             :provided {:dependencies [[cascalog/cascalog-core "1.10.1-SNAPSHOT"]]}})

--- a/midje-cascalog/src/midje/cascalog.clj
+++ b/midje-cascalog/src/midje/cascalog.clj
@@ -125,3 +125,6 @@
 (defmirror incipient-facts)
 (defmirror antiterminologicaldisintactitudinarian-fact)
 (defmirror antiterminologicaldisintactitudinarian-facts)
+
+(defmacro tabular?- [fact-form & table]
+  `(midje.sweet/tabular ~(macroexpand-1 fact-form) ~@table))

--- a/midje-cascalog/test/midje/cascalog_test.clj
+++ b/midje-cascalog/test/midje/cascalog_test.clj
@@ -7,8 +7,6 @@
         [clojure.math.combinatorics :only [permutations]])
   (:require [cascalog.ops :as c]))
 
-; TODO failing, update tests
-
 ;; ## Testing Battery
 
 (defn whoop [x] [[x]])
@@ -31,20 +29,19 @@
                       (fact (whoop :a) => 10)))
 
 ;; Similar to clojure.test's "are".
-(deftest tabular-test
-  (tabular
+(deftest tabular?-test
+  (tabular?-
     (fact?- ?res (apply ?func ?args))
     ?res    ?func    ?args
     [[3 5]] my-query [3 3 5]
     [[1]]   a-query  [[1]]))
 
 (deftest fact?<-test
-  (let [some-seq [[10]]]
-    "Use fact?<- to tests and define a function at the same time."
-    (fact?<- some-seq
-             [?a]
-             ((whoop :a) ?a)
-             (provided (whoop :a) => [[10]]))))
+  "Use fact?<- to tests and define a function at the same time."
+  (fact?<- [[10]]
+           [?a]
+           ((whoop :a) ?a)
+           (provided (whoop :a) => [[10]])))
 
 (deftest background-fact<-test
   (let [result-seq [[3 5]]]
@@ -85,7 +82,7 @@
            [[10 11]]
            [?a ?b]
            ((whoop) ?a ?b)
-           ((bang) ?b :> true)
+           ((bang) ?b)
            (against-background
              (whoop) => [[10 11] [12 13]]
              (bang)  => [[11]]))) 
@@ -98,11 +95,11 @@
     tests."
     (a-query [[10]]) => (produces [[10]])
     (<- [?a ?b]
-        ((bang .a. .b.) ?a ?b)
-        ((whoop .c.) ?b :> true)) => (produces [[10 11]])
+        ((whoop) ?a ?b)
+        ((bang) ?b :> true)) => (produces [[10 11]])
     (against-background
-      (bang .a. .b.) => [[10 11] [12 13]]
-      (whoop .c.)  => [[11]])) 
+      (whoop) => [[10 11] [12 13]]
+      (bang)  => [[11]])) 
   (let [some-seq [[10]]]
     (fact
       "use `produces` to check that the supplied query, when executed,


### PR DESCRIPTION
- introduce `tabular?-` as @marick suggest in #109
- clean project.clj, depends on cascalog-core as `:provided` so as not to be circular dependency
- wrap facts into deftest

cascalog form `facts-` etc are still broken with midje 1.5
