### PR TITLE
restrict cascalog-core dep as :provided in contribs, exclude cascading-h...

### DIFF
--- a/cascalog-checkpoint/project.clj
+++ b/cascalog-checkpoint/project.clj
@@ -3,10 +3,10 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :repositories {"conjars.org" "http://conjars.org/repo"}
-  :dependencies [[cascalog/cascalog-core "1.10.1-SNAPSHOT"]
-                 [jackknife "0.1.2"]
+  :dependencies [[jackknife "0.1.2"]
                  [hadoop-util "0.2.8"]]
   :profiles {:1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
-             :1.5 {:dependencies [[org.clojure/clojure "1.5.0-RC1"]]}
+             :1.5 {:dependencies [[org.clojure/clojure "1.5.0"]]}
+             :provided {:dependencies [[cascalog/cascalog-core "1.10.1-SNAPSHOT"]]}
              :dev {:dependencies
                    [[org.apache.hadoop/hadoop-core "1.0.3"]]}})

--- a/cascalog-core/project.clj
+++ b/cascalog-core/project.clj
@@ -24,10 +24,9 @@
                  [jackknife "0.1.2"]
                  [hadoop-util "0.2.9"]]
   :profiles {:1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
-             :1.5 {:dependencies [[org.clojure/clojure "1.5.0-RC1"]]}
+             :1.5 {:dependencies [[org.clojure/clojure "1.5.0"]]}
              :dev {:resource-paths ["dev"]
-                   :plugins [[lein-midje "3.0-alpha4"]]
+                   :plugins [[lein-midje "3.0-RC1"]]
                    :dependencies
-                   [[midje "1.5-alpha10"]
-                    [midje-cascalog "0.4.0" :exclusions [org.clojure/clojure]]]}
+                   [[cascalog/midje-cascalog "1.10.1-SNAPSHOT" :exclusions [org.clojure/clojure]]]}
              :provided {:dependencies [[org.apache.hadoop/hadoop-core "1.0.3"]]}})

--- a/cascalog-elephantdb/project.clj
+++ b/cascalog-elephantdb/project.clj
@@ -7,13 +7,12 @@
   :java-source-paths ["src/jvm"]
   :javac-options ["-source" "1.6" "-target" "1.6"]
   :jvm-opts ["-server" "-Xmx768m"]
-  :dependencies [[cascalog/cascalog-core "1.10.1-SNAPSHOT"]
-                 [elephantdb/elephantdb-cascading "0.3.5"]]
-  :plugins [[lein-midje "3.0-alpha4"]]
+  :dependencies [[elephantdb/elephantdb-cascading "0.3.5"]]
+  :plugins [[lein-midje "3.0-RC1"]]
   :profiles {:1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
-             :1.5 {:dependencies [[org.clojure/clojure "1.5.0-RC1"]]}
+             :1.5 {:dependencies [[org.clojure/clojure "1.5.0"]]}
+             :provided {:dependencies [[cascalog/cascalog-core "1.10.1-SNAPSHOT"]]}
              :dev {:dependencies
                    [[org.apache.hadoop/hadoop-core "1.0.3"]
-                    [midje "1.5-alpha10"]
-                    [midje-cascalog "0.4.0"
+                    [cascalog/midje-cascalog "1.10.1-SNAPSHOT"
                      :exclusions [org.clojure/clojure]]]}})

--- a/cascalog-lzo/project.clj
+++ b/cascalog-lzo/project.clj
@@ -3,14 +3,14 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :repositories {"conjars.org" "http://conjars.org/repo"}
-  :dependencies [[cascalog/cascalog-core "1.10.1-SNAPSHOT"]
-                 [com.twitter.elephantbird/elephant-bird-cascading2 "3.0.7"]
+  :dependencies [[com.twitter.elephantbird/elephant-bird-cascading2 "3.0.7" :exclusions [cascading/cascading-hadoop]]
                  [hadoop-lzo "0.4.15"]]
-  :plugins [[lein-midje "3.0-beta1"]]
+  :plugins [[lein-midje "3.0-RC1"]]
   :profiles {:1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
-             :1.5 {:dependencies [[org.clojure/clojure "1.5.0-RC1"]]}
+             :1.5 {:dependencies [[org.clojure/clojure "1.5.0"]]}
+             :provided {:dependencies [[cascalog/cascalog-core "1.10.1-SNAPSHOT"]
+                                       [org.apache.hadoop/hadoop-core "1.0.3"]
+                                       [org.apache.httpcomponents/httpclient "4.2.3"]]}
              :dev {:dependencies
-                   [[org.apache.hadoop/hadoop-core "1.0.3"]    
-                    [org.apache.httpcomponents/httpclient "4.2.3"]                
-                    [cascalog/midje-cascalog "1.10.1-SNAPSHOT"
+                   [[cascalog/midje-cascalog "1.10.1-SNAPSHOT"
                      :exclusions [org.clojure/clojure]]]}})

--- a/cascalog-math/project.clj
+++ b/cascalog-math/project.clj
@@ -3,10 +3,10 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :repositories {"conjars.org" "http://conjars.org/repo"}
-  :dependencies [[cascalog/cascalog-core "1.10.1-SNAPSHOT"]]
   :profiles {:1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
-             :1.5 {:dependencies [[org.clojure/clojure "1.5.0-RC1"]]}
+             :1.5 {:dependencies [[org.clojure/clojure "1.5.0"]]}
+             :provided {:dependencies [[cascalog/cascalog-core "1.10.1-SNAPSHOT"]]}
              :dev {:dependencies
-                   [[org.apache.hadoop/hadoop-core "1.0.3"]                    
-                    [midje-cascalog "0.4.0"
+                   [[org.apache.hadoop/hadoop-core "1.0.3"]
+                    [cascalog/midje-cascalog "1.10.1-SNAPSHOT"
                      :exclusions [org.clojure/clojure]]]}})

--- a/cascalog-more-taps/project.clj
+++ b/cascalog-more-taps/project.clj
@@ -3,11 +3,9 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :repositories {"conjars.org" "http://conjars.org/repo"}
-  :dependencies [[cascalog/cascalog-core "1.10.1-SNAPSHOT"]]
-  :plugins [[lein-midje "3.0-alpha4"]]
   :profiles {:1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
-             :1.5 {:dependencies [[org.clojure/clojure "1.5.0-RC1"]]}
+             :1.5 {:dependencies [[org.clojure/clojure "1.5.0"]]}
+             :provided {:dependencies [[cascalog/cascalog-core "1.10.1-SNAPSHOT"]]}
              :dev {:dependencies
                    [[org.apache.hadoop/hadoop-core "1.0.3"]
-                    [midje "1.5-alpha10"]
-                    [midje-cascalog "0.4.0" :exclusions [org.clojure/clojure]]]}})
+                    [cascalog/midje-cascalog "1.10.1-SNAPSHOT" :exclusions [org.clojure/clojure]]]}})

--- a/midje-cascalog/project.clj
+++ b/midje-cascalog/project.clj
@@ -3,8 +3,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :repositories {"conjars.org" "http://conjars.org/repo"}
-  :dependencies [[midje "1.5-beta2"]]
-  :plugins [[lein-midje "3.0-beta1"]]
+  :dependencies [[midje "1.5-RC1"]]
+  :plugins [[lein-midje "3.0-RC1"]]
   :profiles {:1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.0-RC1"]]}
              :dev {:dependencies [[org.apache.hadoop/hadoop-core "1.0.3"]]}


### PR DESCRIPTION
...adoop in elephant-bird

cleaning up project.clj

and clojure 1.5-RC1 to 1.5.0
and midje use RC1 too
