### PR TITLE
option to enable compression for hfl-delimited output tap

### DIFF
--- a/cascalog-more-taps/src/cascalog/more_taps.clj
+++ b/cascalog-more-taps/src/cascalog/more_taps.clj
@@ -8,14 +8,14 @@
            [cascading.tuple Fields]))
 
 (defn- delimited
-  [field-seq delim & {:keys [classes compress skip-header? quote write-header? strict? safe?]
+  [field-seq delim & {:keys [classes compress? skip-header? quote write-header? strict? safe?]
                       :or {quote "\"", strict? true, safe? true}}]
   (let [[skip-header? write-header? strict? safe?] (map boolean [skip-header? write-header? strict? safe?])
         field-seq    (w/fields field-seq)
         field-seq    (if (and classes (not (.isDefined field-seq)))
                        (w/fields (v/gen-nullable-vars (count classes)))
                        field-seq)
-        compression (if compress TextLine$Compress/ENABLE TextLine$Compress/DEFAULT)]
+        compression (if compress? TextLine$Compress/ENABLE TextLine$Compress/DEFAULT)]
     (if classes
       (TextDelimited. field-seq compression skip-header? write-header?
                       delim strict? quote (into-array classes) safe?)
@@ -28,8 +28,8 @@
   prefixes for `path`.
 
   Supports TextDelimited keyword option for `:outfields`, `:classes`,
-  `:skip-header?`, `:delimiter`, `:write-header?`, `:strict?`, `safe?`,
-  and `:quote`.
+  `:compress?`, `:skip-header?`, `:delimiter`, `:write-header?`, `:strict?`,
+  `safe?`, and `:quote`.
   See `cascalog.tap/hfs-tap` for more keyword arguments.
 
   See http://www.cascading.org/javadoc/cascading/tap/Hfs.html and
@@ -50,8 +50,8 @@
   using different prefixes for `path`.
 
   Supports TextDelimited keyword option for `:outfields`, `:classes`,
-  `:skip-header?`, `:delimiter`, `:write-header?`, `:strict?`, `safe?`,
-  and `:quote`.
+  `:compress?`, `:skip-header?`, `:delimiter`, `:write-header?`, `:strict?`,
+  `safe?`, and `:quote`.
   See `cascalog.tap/hfs-tap` for more keyword arguments.
 
   See http://www.cascading.org/javadoc/cascading/tap/Hfs.html and

--- a/cascalog-more-taps/test/cascalog/more_taps_test.clj
+++ b/cascalog-more-taps/test/cascalog/more_taps_test.clj
@@ -23,9 +23,9 @@
 
 (fact
   (io/with-fs-tmp [_ tmp]
-    (?- (hfs-delimited tmp :delimiter "," :compress true)   ;; write line
+    (?- (hfs-delimited tmp :delimiter "," :compress? true)   ;; write line
         [["Proin" false 3]])
     (fact "Compression"
       (<- [?a ?b ?c]
-          ((hfs-delimited tmp :delimiter "," :compress true) ?a ?b ?c)) =>
+          ((hfs-delimited tmp :delimiter "," :compress? true) ?a ?b ?c)) =>
       (produces [["Proin" "false" "3"]]))))


### PR DESCRIPTION
When gzip (or otherwise) compressing the output of a query using e.g.

``` clojure
(with-job-conf {"mapred.output.compress" "true"
                "mapred.output.compression.codec" "org.apache.hadoop.io.compress.GzipCodec"
  (?<- (hfs-delimited output-path) [["Proin"]]))
```

I was not getting compressed output.  With this change adding `:compress true` as an option to `hfs-delimited` sets compression on the schema.

I experimented with other `JobConf` settings and this is what worked.  This may just be a request for comment, is there a way to force compression without directly modify the taps?
