### PR TITLE
cascalog-map[cat]

### DIFF
--- a/cascalog-core/src/clj/cascalog/testing.clj
+++ b/cascalog-core/src/clj/cascalog/testing.clj
@@ -37,7 +37,7 @@
 
 (defn collect-to
   [^TupleEntryCollector collector v]
-  (let [^Tuple t (if (coll? v)
+  (let [^Tuple t (if (instance? java.util.List v)
                    (Tuple. (to-array v))
                    (doto (Tuple.) (.add v)))]
     (.add collector t)))


### PR DESCRIPTION
I've refactored cascalog-map slightly removing calls to Utils and implemented mapcat. Also added state passing, though going through partial is probably going to be more overhead than acceptable here.

These are about 50% slower than java versions. Still it adds only 0.5 sec for 1M tuples on my laptop, so probably ok.
