### PR TITLE
switch to hadoop 1.1.2 for cascading 2.2 compatibility and speed up tests

### DIFF
--- a/cascalog-core/project.clj
+++ b/cascalog-core/project.clj
@@ -34,4 +34,4 @@
                    [[cascalog/midje-cascalog "1.10.2-SNAPSHOT"]
                     [org.apache.hadoop/hadoop-core "1.1.2" :exclusions [[org.slf4j/slf4j-log4j12] [log4j] [commons-codec] commons-logging]]]}
              :ci-dev [:dev {:dependencies [[cascalog/midje-cascalog "1.10.1"]
-                                           [org.apache.hadoop/hadoop-core "1.0.3"]]}]})
+                                           [org.apache.hadoop/hadoop-core "1.1.2"]]}]})


### PR DESCRIPTION
switching to a modern version of hadoop is necessary for the upcoming cascading 2.2, which will drop support for hadoop 0.20.2. This also makes the tests run a bit faster.
