### PR TITLE
add config setting to retain outputcollector. 

### DIFF
--- a/cascalog-core/src/clj/cascalog/conf.clj
+++ b/cascalog-core/src/clj/cascalog/conf.clj
@@ -27,7 +27,9 @@
                  *JOB-CONF*
                  {"io.serializations"
                   "cascalog.hadoop.ClojureKryoSerialization",
-                  cascading.flow.stream.OperatorStage/RETAIN_COLLECTOR
+                  "cascading.compatibility.retain.collector"
+                  ; defined in cascading.flow.stream.OperatorStage/RETAIN_COLLECTOR as of 
+                  ; Cascading 2.2
                   true}))
 
 (defn set-job-conf! [amap]


### PR DESCRIPTION
This is needed for Cascading 2.2 compatibility and fixes/works around https://github.com/nathanmarz/cascalog/issues/159
