### PR TITLE
set cascading framework property correctly

### DIFF
--- a/cascalog-core/src/clj/cascalog/conf.clj
+++ b/cascalog-core/src/clj/cascalog/conf.clj
@@ -1,8 +1,10 @@
 (ns cascalog.conf
   (:use [cascalog.util :only (project-merge)]
-        [clojure.java.io :only (resource)])
+        [clojure.java.io :as io])
   (:require [jackknife.core :as u])
-  (:import [cascading.flow FlowProps]))
+  (:import [cascading.flow FlowProps]
+           [cascading.property AppProps]
+           [java.util Properties]))
 
 (defn read-settings [x]
   (try (binding [*ns* (create-ns (gensym "settings"))]
@@ -12,7 +14,7 @@
          (u/throw-runtime "Error reading job-conf.clj!\n\n" e))))
 
 (defn project-settings []
-  (if-let [conf-path (resource "job-conf.clj")]
+  (if-let [conf-path (io/resource "job-conf.clj")]
     (let [conf (-> conf-path slurp read-settings project-merge)]
       (u/safe-assert (map? conf)
                      "job-conf.clj must end with a map of config parameters.")
@@ -34,3 +36,18 @@
 
 (defn set-job-conf! [amap]
   (alter-var-root #'*JOB-CONF* (fn [& ignored] (into {} amap))))
+
+(defn get-version [dep]
+  ;; read the project version from the pom.properties file in the jar
+  (let [path (str "META-INF/maven/" (name dep) "/pom.properties")
+        props (io/resource path)]
+    (when props
+      (with-open [stream (io/input-stream props)]
+        (let [props (doto (Properties.) (.load stream))]
+          (.getProperty props "version"))))))
+
+(System/setProperty AppProps/APP_FRAMEWORKS 
+  ;; being a good citizen in the cascading ecosystem and set the framework 
+  ;; property
+       (str, "cascalog:" 
+            (get-version "cascalog/cascalog-core")))

--- a/cascalog-core/src/clj/cascalog/util.clj
+++ b/cascalog-core/src/clj/cascalog/util.clj
@@ -4,10 +4,7 @@
         [jackknife.seq :only (unweave merge-to-vec collectify)])
   (:require [clojure.string :as s])
   (:require [clojure.java.io :as io]) 
-  (:import [java.util UUID]
-           [java.util Properties]
-           [cascading.property AppProps]
-           ))
+  (:import [java.util UUID]))
 (defn multifn? [x]
   (instance? clojure.lang.MultiFn x))
 
@@ -170,19 +167,3 @@
        (filter (complement recent-eval?))
        (sort-by (fn [v] (if (-> v meta :dynamic) 1 0)))
        first))
-
-
-(defn get-version [dep]
-  ;; read the project version from the pom.properties file in the jar
-  (let [path (str "META-INF/maven/" (name dep) "/pom.properties")
-        props (io/resource path)]
-    (when props
-      (with-open [stream (io/input-stream props)]
-        (let [props (doto (Properties.) (.load stream))]
-          (.getProperty props "version"))))))
-
-(System/setProperty AppProps/APP_FRAMEWORKS 
-  ;; being a good citizen in the cascading ecosystem and set the framework 
-  ;; property
-       (s/join "", ["cascalog", ":" 
-            (get-version "cascalog/cascalog-core")]))


### PR DESCRIPTION
For logging purpose and the update feature of cascading, it is a common practice to set the "cascading.app.frameworks" System-property with the name of the project and it's version. 

We do this for all projects based on cascading upstream. 

This patch enables it for cascalog.
