### PR TITLE
Changed dependency declaration to work w/ lein 2 + clojure 1.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The best way to get started with Cascalog is experiment with the toy datasets th
 1. Install [leiningen](http://github.com/technomancy/leiningen)
 2. Make sure you have Java 1.6 (run `java -version`)
 3. Start a new leiningen project with `lein new <project name>`, replacing `<project name>`
-4. Include dependency on Cascalog in your project by adding `[cascalog/cascalog-core "2.0.0-SNAPSHOT"]` into your project's `project.clj` file.
+4. Include dependency on Cascalog in your project by adding `[cascalog "2.0.0-SNAPSHOT"]` into your project's `project.clj` file.
 5. Work through the examples in the [Getting Started Guide](http://cascalog.org/articles/getting_started.html).
 
 # Using Cascalog within a project


### PR DESCRIPTION
Hi Nathan,

I had problems resolving the dependency in your branch's README when qualified as
'cascalog/cascalog-core' (for 2.0.0-SNAPSHOT), but none with using 'cascalog,' which 
is also consistent with instructions here: 

https://clojars.org/cascalog/versions/2.0.0-SNAPSHOT .

Cheers, Russell
