### PR TITLE
Adds nil-tolerant aggregates.

### DIFF
--- a/cascalog-core/src/clj/cascalog/logic/ops.clj
+++ b/cascalog-core/src/clj/cascalog/logic/ops.clj
@@ -184,7 +184,6 @@
   (each impl/comparable-max-parallel))
 
 (def !count (each impl/!count-parallel))
-(def count! (each impl/!count-parallel))
 
 (def null-safe-sum (impl/nil-safe-combiner +))
 
@@ -201,8 +200,6 @@
   "Same as sum, but discards nil values. Result is the sum of all
   numeric values, or nil if all inputs are nil."
   (each !sum-parallel))
-
-(def sum! !sum)
 
 (def !avg
   "Same as avg, but discards nil values. Result is the sum of all

--- a/cascalog-core/src/clj/cascalog/logic/ops.clj
+++ b/cascalog-core/src/clj/cascalog/logic/ops.clj
@@ -161,13 +161,62 @@
   :init-var #'impl/one
   :combine-var #'+)
 
+(defaggregateop distinct-count-agg!
+  ([] [nil 0])
+  ([[prev cnt] & tuple]
+     [tuple (impl/distinct-count-impl prev cnt tuple)])
+  ([state] [(second state)]))
+
 (def sum (each impl/sum-parallel))
 
 (def min (each impl/min-parallel))
 
+(def min!
+  "Same as min, but discards nil values."
+  (each impl/comparable-min-parallel))
+
 (def max (each impl/max-parallel))
 
-(def !count (each impl/!count-parallel))
+(def max!
+  "Same as max, but discards nil values."
+  (each impl/comparable-max-parallel))
+
+(def !count (each impl/count-parallel!))
+
+(def null-safe-sum (impl/nil-safe-combiner +))
+
+(defn nil-save-div [numer denom]
+  (if (zero? denom)
+    nil
+    (/ (double numer) denom)))
+
+(defparallelagg !sum-parallel
+  :init-var #'identity
+  :combine-var #'null-safe-sum)
+
+(def sum!
+  "Same as sum, but discards nil values."
+  (each !sum-parallel))
+
+(def avg!
+  "Same as avg, but discards nil values."
+  (<- [!v :> !avg]
+      (!count !v :> !c)
+      (!sum !v :> !s)
+      (nil-save-div !s !c :> !avg)))
+
+(def distinct-count!
+  "Predicate operation that produces a count of all distinct
+   values of the supplied input variable. For example:
+
+   (let [src [[1] [2] [2]]]
+     (<- [?count]
+         (src ?x)
+         (distinct-count! ?x :> ?count)))
+   ;;=> ([2])"
+  (<- [:<< !invars :> !c]
+      (:sort :<< !invars)
+      (distinct-count-agg! :<< !invars :> !c)))
 
 (defn limit-init [sort-tuple & tuple]
   ;; this is b/c CombinerBase does coerceToSeq on everything and

--- a/cascalog-core/src/clj/cascalog/logic/ops.clj
+++ b/cascalog-core/src/clj/cascalog/logic/ops.clj
@@ -171,21 +171,24 @@
 
 (def min (each impl/min-parallel))
 
-(def min!
-  "Same as min, but discards nil values."
+(def !min
+  "Same as min, but discards nil values. Returns the minimum of all
+  non-nil values, or nil if all inputs are nil."
   (each impl/comparable-min-parallel))
 
 (def max (each impl/max-parallel))
 
-(def max!
-  "Same as max, but discards nil values."
+(def !max
+  "Same as max, but discards nil values. Returns the maximum of all
+  non-nil values, or nil if all inputs are nil."
   (each impl/comparable-max-parallel))
 
-(def !count (each impl/count-parallel!))
+(def !count (each impl/!count-parallel))
+(def count! (each impl/!count-parallel))
 
 (def null-safe-sum (impl/nil-safe-combiner +))
 
-(defn nil-save-div [numer denom]
+(defn nil-safe-div [numer denom]
   (if (zero? denom)
     nil
     (/ (double numer) denom)))
@@ -194,25 +197,30 @@
   :init-var #'identity
   :combine-var #'null-safe-sum)
 
-(def sum!
-  "Same as sum, but discards nil values."
+(def !sum
+  "Same as sum, but discards nil values. Result is the sum of all
+  numeric values, or nil if all inputs are nil."
   (each !sum-parallel))
 
-(def avg!
-  "Same as avg, but discards nil values."
-  (<- [!v :> !avg]
+(def sum! !sum)
+
+(def !avg
+  "Same as avg, but discards nil values. Result is the sum of all
+  non-nil values plus the count of all non-nil values, or nil if all
+  inputs are nil."
+  (<- [!v :> !result]
       (!count !v :> !c)
       (!sum !v :> !s)
-      (nil-save-div !s !c :> !avg)))
+      (nil-safe-div !s !c :> !result)))
 
-(def distinct-count!
+(def !distinct-count
   "Predicate operation that produces a count of all distinct
    values of the supplied input variable. For example:
 
    (let [src [[1] [2] [2]]]
      (<- [?count]
          (src ?x)
-         (distinct-count! ?x :> ?count)))
+         (!distinct-count ?x :> ?count)))
    ;;=> ([2])"
   (<- [:<< !invars :> !c]
       (:sort :<< !invars)

--- a/cascalog-core/src/clj/cascalog/logic/ops_impl.clj
+++ b/cascalog-core/src/clj/cascalog/logic/ops_impl.clj
@@ -8,6 +8,34 @@
 
 (defn existence-int [v] (if v 1 0))
 
+(defn nil-safe-combiner 
+  "Takes a function f of two variables, and returns a function
+   of two variables that calls f on its arguments only if both
+   are non-nil. If one argument is nil, it prefers the other argument,
+   and if both are nil it returns nil."
+  [f]
+  (fn [x y]
+    (cond 
+     (and (nil? x) (nil? y)) nil
+     (nil? x) y
+     (nil? y) x
+     :else (f x y))))
+
+(defn smaller [x y]
+  (if (neg? (compare x y)) x y))
+
+(defn larger [x y]
+  (if (pos? (compare x y)) x y))
+
+(def comparable-min-impl (nil-safe-combiner smaller))
+
+(def comparable-max-impl (nil-safe-combiner larger))
+
+(defn distinct-count-impl [prev cnt tuple]
+  (if (or (every? nil? tuple) (= tuple prev))
+    cnt
+    (inc cnt)))
+
 (defparallelagg sum-parallel
   :init-var #'identity
   :combine-var #'+)
@@ -16,11 +44,19 @@
   :init-var #'identity
   :combine-var #'min)
 
+(defparallelagg comparable-min-parallel 
+  :init-var #'identity
+  :combine-var #'comparable-min-impl)
+
 (defparallelagg max-parallel
   :init-var #'identity
   :combine-var #'max)
 
-(defparallelagg !count-parallel
+(defparallelagg comparable-max-parallel 
+  :init-var #'identity
+  :combine-var #'comparable-max-impl)
+
+(defparallelagg count-parallel!
   :init-var #'existence-int
   :combine-var #'+)
 

--- a/cascalog-core/src/clj/cascalog/logic/ops_impl.clj
+++ b/cascalog-core/src/clj/cascalog/logic/ops_impl.clj
@@ -56,7 +56,7 @@
   :init-var #'identity
   :combine-var #'comparable-max-impl)
 
-(defparallelagg count-parallel!
+(defparallelagg !count-parallel
   :init-var #'existence-int
   :combine-var #'+)
 

--- a/cascalog-core/test/cascalog/logic/defops_test.clj
+++ b/cascalog-core/test/cascalog/logic/defops_test.clj
@@ -1,7 +1,8 @@
 (ns cascalog.logic.defops-test
   (:use cascalog.api
         clojure.test
-        [midje sweet cascalog]))
+        [midje sweet cascalog])
+  (:require [cascalog.logic.ops]))
 
 (defmapop ident [x] x)
 
@@ -79,93 +80,73 @@
                (src ?a ?b ?c ?d ?e)
                (multi-combine ?a ?b ?c ?d ?e :> ?sum)))))
 
-(deftest min!-test
-  (facts "Null safe min aggregate"
-         (let [src [[0] [1] [2] [nil]]]
-           (fact?<- [[0]]
-                    [?min]
-                    (src ?x)
-                    (cascalog.logic.ops/min! ?x :> ?min)))
-         (let [src [[-99] [nil] [nil]]]
-           (fact?<- [[-99]]
-                    [?min]
-                    [src ?x]
-                    (cascalog.logic.ops/min! ?x :> ?min)))
-         (let [src [[nil]]]
-           (fact?<- []
-                    [?min]
-                    [src ?x]
-                    (cascalog.logic.ops/min! ?x :> ?min)))))
+(deftest !sum-test
+  (let [src [["a" 1]
+             ["a" 2]
+             ["b" 5]
+             ["b" nil]
+             ["c" nil]]]
+    (fact
+     (<- [?id !total]
+         (src ?id !x)
+         (cascalog.logic.ops/!sum !x :> !total))
+     => (produces [["a" 3]
+                   ["b" 5]
+                   ["c" nil]]))))
 
-(deftest max!-test
-  (facts "Null safe max aggregate"
-         (let [src [[0] [1] [2] [nil]]]
-           (fact?<- [[2]]
-                    [?max]
-                    (src ?x)
-                    (cascalog.logic.ops/max! ?x :> ?max)))
-         (let [src [[-99] [nil] [nil]]]
-           (fact?<- [[-99]]
-                    [?max]
-                    [src ?x]
-                    (cascalog.logic.ops/max! ?x :> ?max)))
-         (let [src [[nil]]]
-           (fact?<- []
-                    [?max]
-                    [src ?x]
-                    (cascalog.logic.ops/max! ?x :> ?max)))))
+(deftest !avg-test
+  (let [src [["a" 1]
+             ["a" 2]
+             ["b" 5]
+             ["b" nil]
+             ["c" nil]]]
+    (fact
+     (<- [?id !avg]
+         (src ?id !x)
+         (cascalog.logic.ops/!avg !x :> !avg))
+     => (produces [["a" 1.5]
+                   ["b" 5.0]
+                   ["c" nil]]))))
 
-(deftest sum!-test
-  (facts "Null safe sum aggregate"
-         (let [src [[0] [1] [2] [nil]]]
-           (fact?<- [[3]]
-                    [?sum]
-                    (src ?x)
-                    (cascalog.logic.ops/sum! ?x :> ?sum)))
-         (let [src [[-99] [nil] [nil]]]
-           (fact?<- [[-99]]
-                    [?sum]
-                    [src ?x]
-                    (cascalog.logic.ops/sum! ?x :> ?sum)))
-         (let [src [[nil]]]
-           (fact?<- []
-                    [?sum]
-                    [src ?x]
-                    (cascalog.logic.ops/sum! ?x :> ?sum)))))
+(deftest !min-test
+  (let [src [["a" 1]
+             ["a" 2]
+             ["b" 5]
+             ["b" nil]
+             ["c" nil]]]
+    (fact
+     (<- [?id !min]
+         (src ?id !x)
+         (cascalog.logic.ops/!min !x :> !min))
+     => (produces [["a" 1]
+                   ["b" 5]
+                   ["c" nil]]))))
 
-(deftest avg!-test
-  (facts "Null safe avg aggregate"
-         (let [src [[0] [1] [2] [nil]]]
-           (fact?<- [[1]]
-                    [?avg]
-                    (src ?x)
-                    (cascalog.logic.ops/avg! ?x :> ?avg)))
-         (let [src [[-99] [nil] [nil]]]
-           (fact?<- [[-99]]
-                    [?avg]
-                    [src ?x]
-                    (cascalog.logic.ops/avg! ?x :> ?avg)))
-         (let [src [[nil]]]
-           (fact?<- []
-                    [?avg]
-                    [src ?x]
-                    (cascalog.logic.ops/avg! ?x :> ?avg)))))
+(deftest !max-test
+  (let [src [["a" 1]
+             ["a" 2]
+             ["b" 5]
+             ["b" nil]
+             ["c" nil]]]
+    (fact
+     (<- [?id !max]
+         (src ?id !x)
+         (cascalog.logic.ops/!max !x :> !max))
+     => (produces [["a" 2]
+                   ["b" 5]
+                   ["c" nil]]))))
 
-(deftest distinct-count!-test
-  (facts "Null safe distinct count aggregate"
-         (let [src [[0] [1] [2] [2] [nil]]]
-           (fact?<- [[3]]
-                    [?count]
-                    (src ?x)
-                    (cascalog.logic.ops/distinct-count! ?x :> ?count)))
-         (let [src [[-99] [nil] [nil]]]
-           (fact?<- [[1]]
-                    [?count]
-                    [src ?x]
-                    (cascalog.logic.ops/distinct-count! ?x :> ?count)))
-         (let [src [[nil]]]
-           (fact?<- []
-                    [?count]
-                    [src ?x]
-                    (cascalog.logic.ops/distinct-count! ?x :> ?count)))))
+(deftest !distinct-count-test
+  (let [src [["a" 1]
+             ["a" 2]
+             ["b" 5]
+             ["b" nil]
+             ["c" nil]]]
+    (fact
+     (<- [?id !distinct-count]
+         (src ?id !x)
+         (cascalog.logic.ops/!distinct-count !x :> !distinct-count))
+     => (produces [["a" 2]
+                   ["b" 1]
+                   ["c" 0]]))))
 

--- a/cascalog-core/test/cascalog/logic/defops_test.clj
+++ b/cascalog-core/test/cascalog/logic/defops_test.clj
@@ -78,3 +78,94 @@
                [?sum]
                (src ?a ?b ?c ?d ?e)
                (multi-combine ?a ?b ?c ?d ?e :> ?sum)))))
+
+(deftest min!-test
+  (facts "Null safe min aggregate"
+         (let [src [[0] [1] [2] [nil]]]
+           (fact?<- [[0]]
+                    [?min]
+                    (src ?x)
+                    (cascalog.logic.ops/min! ?x :> ?min)))
+         (let [src [[-99] [nil] [nil]]]
+           (fact?<- [[-99]]
+                    [?min]
+                    [src ?x]
+                    (cascalog.logic.ops/min! ?x :> ?min)))
+         (let [src [[nil]]]
+           (fact?<- []
+                    [?min]
+                    [src ?x]
+                    (cascalog.logic.ops/min! ?x :> ?min)))))
+
+(deftest max!-test
+  (facts "Null safe max aggregate"
+         (let [src [[0] [1] [2] [nil]]]
+           (fact?<- [[2]]
+                    [?max]
+                    (src ?x)
+                    (cascalog.logic.ops/max! ?x :> ?max)))
+         (let [src [[-99] [nil] [nil]]]
+           (fact?<- [[-99]]
+                    [?max]
+                    [src ?x]
+                    (cascalog.logic.ops/max! ?x :> ?max)))
+         (let [src [[nil]]]
+           (fact?<- []
+                    [?max]
+                    [src ?x]
+                    (cascalog.logic.ops/max! ?x :> ?max)))))
+
+(deftest sum!-test
+  (facts "Null safe sum aggregate"
+         (let [src [[0] [1] [2] [nil]]]
+           (fact?<- [[3]]
+                    [?sum]
+                    (src ?x)
+                    (cascalog.logic.ops/sum! ?x :> ?sum)))
+         (let [src [[-99] [nil] [nil]]]
+           (fact?<- [[-99]]
+                    [?sum]
+                    [src ?x]
+                    (cascalog.logic.ops/sum! ?x :> ?sum)))
+         (let [src [[nil]]]
+           (fact?<- []
+                    [?sum]
+                    [src ?x]
+                    (cascalog.logic.ops/sum! ?x :> ?sum)))))
+
+(deftest avg!-test
+  (facts "Null safe avg aggregate"
+         (let [src [[0] [1] [2] [nil]]]
+           (fact?<- [[1]]
+                    [?avg]
+                    (src ?x)
+                    (cascalog.logic.ops/avg! ?x :> ?avg)))
+         (let [src [[-99] [nil] [nil]]]
+           (fact?<- [[-99]]
+                    [?avg]
+                    [src ?x]
+                    (cascalog.logic.ops/avg! ?x :> ?avg)))
+         (let [src [[nil]]]
+           (fact?<- []
+                    [?avg]
+                    [src ?x]
+                    (cascalog.logic.ops/avg! ?x :> ?avg)))))
+
+(deftest distinct-count!-test
+  (facts "Null safe distinct count aggregate"
+         (let [src [[0] [1] [2] [2] [nil]]]
+           (fact?<- [[3]]
+                    [?count]
+                    (src ?x)
+                    (cascalog.logic.ops/distinct-count! ?x :> ?count)))
+         (let [src [[-99] [nil] [nil]]]
+           (fact?<- [[1]]
+                    [?count]
+                    [src ?x]
+                    (cascalog.logic.ops/distinct-count! ?x :> ?count)))
+         (let [src [[nil]]]
+           (fact?<- []
+                    [?count]
+                    [src ?x]
+                    (cascalog.logic.ops/distinct-count! ?x :> ?count)))))
+


### PR DESCRIPTION
Mirrors of functions that normally blow up when they counter nil.
Instead, these passively discard nil values.

We avoided the convention of prefixing the function with `!` and used it as a suffix.
Cascalog 2 errored on the query when it was prefixed.