### PR TITLE
Added counterfn - a standard way to access hadoop counters

### DIFF
--- a/cascalog-core/src/clj/cascalog/api.clj
+++ b/cascalog-core/src/clj/cascalog/api.clj
@@ -286,6 +286,8 @@
 
 (defalias defparallelagg d/defparallelagg)
 
+(defalias counterfn d/counterfn)
+
 ;; ## Miscellaneous helpers
 
 (defn div


### PR DESCRIPTION
defprepfn is great. But while accessing hadoop counters is a
little cleaner, it is a little less intuitive because the
prepfn context seems to only be valid from within the query
itself.

This commit adds a proposed counterfn interface to access
hadoop counters, using mapfn to return a serilized function
that can be used to later increment any hadoop counter. If there
is a simpler way to get similar functionality I'd love to
know it. Otherwise, it might be good to offer a utility
function like this to provide a simple interface to hadoop counters.

To use - grab a counter function from within a query:

  (counterfn :> ?inc-counter)

This inc-counter can then be passed around to other functions,
and called:

(inc-counter counter-group counter-name increment-amount)

The increment amount is optional and defaults to 1.

I wasn't sure where this should go, so for the time being
just tacked it at the bottom of def.clj.