### PR TITLE
Fixes url to point to correct blog article regarding testing cascalog 2....

### DIFF
--- a/midje-cascalog/README.md
+++ b/midje-cascalog/README.md
@@ -2,7 +2,7 @@
 
 Midje-Cascalog is a thin layer over [midje](https://github.com/marick/Midje) that makes it easy and fun to test [Cascalog](https://github.com/nathanmarz/cascalog) queries! Scroll down for an in-depth example.
 
-[Cascalog Testing 2.0](http://sritchie.github.com/2012/01/22/cascalog-testing-20.html) gives a long discussion on various midje-cascalog idioms.
+[Cascalog Testing 2.0](http://sritchie.github.com/2012/01/22/cascalog-testing-20/) gives a long discussion on various midje-cascalog idioms.
 
 ## Usage Instructions
 


### PR DESCRIPTION
...0 with midje
