### PR TITLE
Fixes deprecation warnings

### DIFF
--- a/cascalog-core/src/clj/cascalog/logic/def.clj
+++ b/cascalog-core/src/clj/cascalog/logic/def.clj
@@ -123,7 +123,7 @@
   `(defmacro ~old
      [sym# & body#]
      (println ~(format "Warning, %s is deprecated; use %s."
-                       (resolve old)
+                       old
                        (resolve new)))
      `(~'~new ~sym# ~@body#)))
 


### PR DESCRIPTION
The current function deprecation warnings look like: 

```
Warning, null is deprecated; use #'cascalog.logic.def/defmapcatfn.
```

This fixes the message to display the function name so the new messasges will look like:

```
Warning, defmapcatop is deprecated; use #'cascalog.logic.def/defmapcatfn.
```
