### PR TITLE
Preserve order for grouping fields.

### DIFF
--- a/cascalog-core/src/clj/cascalog/logic/parse.clj
+++ b/cascalog-core/src/clj/cascalog/logic/parse.clj
@@ -651,10 +651,9 @@ This won't work in distributed mode because of the ->Record functions."
                                       (assoc :operations operations)))
                                 nodes))
         joined     (merge-tails tails options)
-        grouping-fields (filter (intersection
-                                 (set (:available-fields joined))
-                                 (set fields))
-                                fields)
+        grouping-fields (filter 
+                         (set (:available-fields joined))
+                         fields)
         agg-tail (build-agg-tail joined aggs grouping-fields options)
         {:keys [operations available-fields] :as tail} (add-ops-fixed-point agg-tail)]
     (validate-projection! operations fields available-fields)


### PR DESCRIPTION
Currently, the grouping fields in a query that uses aggregators get put into a scrambled order due to the use of set operations.  This is normally not a problem, but it can become one when you are expecting to see similar groups to be close together, e.g. when using a template tap with template fields that are coarser than the group-by fields.  In this situation, the template tap may be forced to re-open files that it has previously seen, which may cause "file already exists" errors.
