### PR TITLE
rm hgignore syntax: glob and .cake/ in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@ target
 out
 lib
 pom.xml
-# use glob syntax.
-syntax: glob
 *.class
 *.jar
 *~
@@ -16,7 +14,6 @@ syntax: glob
 *.project
 *.settings
 *.dot
-.cake/
 .lein-failures
 .lein-deps-sum
 doc


### PR DESCRIPTION
git complaining about this now for some reason
