### PR TITLE
Correct the use of `format`

### DIFF
--- a/cascalog-core/src/clj/cascalog/logic/options.clj
+++ b/cascalog-core/src/clj/cascalog/logic/options.clj
@@ -31,7 +31,7 @@
   will throw an exception."
   [l r]
   (if-not (or (nil? l) (= l r))
-    (throw-illegal (format "Same option set to conflicting values: % vs %."
+    (throw-illegal (format "Same option set to conflicting values: %s vs %s."
                            l r))
     r))
 

--- a/cascalog-core/src/clj/cascalog/logic/parse.clj
+++ b/cascalog-core/src/clj/cascalog/logic/parse.clj
@@ -621,7 +621,7 @@ This won't work in distributed mode because of the ->Record functions."
         available (:available-fields tail)]
     (u/safe-assert (subset? (set fields)
                             (set available))
-                   (format "Cannot select % from %."
+                   (format "Cannot select %s from %s."
                            fields
                            available))
     (-> tail
@@ -634,7 +634,7 @@ This won't work in distributed mode because of the ->Record functions."
     (u/safe-assert (= (count available)
                       (count fields))
                    (format
-                    "Must rename to the same number of fields. % to % is invalid."
+                    "Must rename to the same number of fields. %s to %s is invalid."
                     fields
                     available))
     (-> tail


### PR DESCRIPTION
In the current code `format` function has format strings passed without conversion specifier, such as `"foo: % bar"` instead of `"foo: %s bar"`. The issue was shadowing prevents display of actual errors and now it seems to work just fine.
