### PR TITLE
Make parallel buffers able to optionally use a bufferiter for the final aggregation

### DIFF
--- a/cascalog-core/src/clj/cascalog/cascading/platform.clj
+++ b/cascalog-core/src/clj/cascalog/cascading/platform.clj
@@ -246,7 +246,8 @@
                   "Only one buffer allowed per subquery.")
           (let [{:keys [op input output]} (first bufs)
                 {:keys [init-var combine-var present-var
-                        num-intermediate-vars-fn buffer-var]} op
+                        num-intermediate-vars-fn buffer-var
+                        buffer-iter?]} op
                 temps (v/gen-nullable-vars
                        (num-intermediate-vars-fn input output))
                 spec (-> (CombinerSpec. combine-var)
@@ -263,7 +264,8 @@
             (apply ops/group-by*
                    source
                    grouping-fields
-                   [(ops/buffer buffer-var temps output)]
+                   [((if buffer-iter? ops/bufferiter ops/buffer)
+                     buffer-var temps output)]
                    (opt-seq options))))
       (let [aggs (map (fn [{:keys [op input output]}]
                         (agg-cascading op input output))


### PR DESCRIPTION
I'm running into a problem where the final reduce-side buffered aggregation for for a parallel buffer operation is running out of memory.  This should help me with that.  Not sure on what the API for it should look like though.
