### PR TITLE
use chill's reflectinginstantiator to allow config registrations

### DIFF
--- a/cascalog-core/src/java/cascalog/kryo/ClojureKryoInstantiator.java
+++ b/cascalog-core/src/java/cascalog/kryo/ClojureKryoInstantiator.java
@@ -3,9 +3,11 @@ package cascalog.kryo;
 import com.esotericsoftware.kryo.Kryo;
 import com.twitter.chill.KryoInstantiator;
 import com.twitter.chill.config.Config;
+import com.twitter.chill.config.ReflectingInstantiator;
+import com.twitter.chill.config.ConfigurationException;
 import org.objenesis.strategy.StdInstantiatorStrategy;
 
-import static carbonite.JavaBridge.defaultRegistry;
+import static carbonite.JavaBridge.enhanceRegistry;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -13,23 +15,29 @@ import java.util.HashSet;
 
 public class ClojureKryoInstantiator extends KryoInstantiator {
 
-  Config config;
+  final Config config;
+  final ReflectingInstantiator reflectingInst;
 
   public ClojureKryoInstantiator(Config config) {
-    this.config = config;
+    try {
+      this.config = config;
+      reflectingInst = new ReflectingInstantiator(config);
+    } catch (ConfigurationException cx) {
+      throw new RuntimeException(cx);
+    }
   }
 
   @Override
   public Kryo newKryo() {
     try {
-      Kryo k = defaultRegistry();
+      Kryo k = reflectingInst.newKryo();
+      // register all the carbonite serializers
+      enhanceRegistry(k);
 
       k.register(ArrayList.class);
       k.register(HashMap.class);
       k.register(HashSet.class);
 
-      k.setRegistrationRequired(config.getBoolean("cascalog.kryo.registrationrequired", false));
-      k.setInstantiatorStrategy(new StdInstantiatorStrategy());
       k.setReferences(config.getBoolean("cascalog.kryo.setreferences", false));
       k.setClassLoader(Thread.currentThread().getContextClassLoader());
 

--- a/cascalog-core/src/java/cascalog/kryo/KryoService.java
+++ b/cascalog-core/src/java/cascalog/kryo/KryoService.java
@@ -12,20 +12,20 @@ public class KryoService {
   static int GUESS_THREADS_PER_CORE = 4;
   static int MAX_CACHED_KRYO = GUESS_THREADS_PER_CORE * Runtime.getRuntime().availableProcessors();
 
-  static final Object _mutex =  new Object();
-  static KryoPool _kpool = null;
+  static final Object mutex =  new Object();
+  static KryoPool kpool = null;
 
   public static KryoPool defaultPool() {
-    synchronized(_mutex) {
-      if (_kpool == null) {
+    synchronized(mutex) {
+      if (kpool == null) {
         try {
           KryoInstantiator kryoInst = new ConfiguredInstantiator(new HadoopConfig(clojureConf()));
-          _kpool = KryoPool.withByteArrayOutputStream(MAX_CACHED_KRYO, kryoInst);
+          kpool = KryoPool.withByteArrayOutputStream(MAX_CACHED_KRYO, kryoInst);
         } catch (ConfigurationException cx) {
           throw new RuntimeException(cx);
         }
       }
-      return _kpool;
+      return kpool;
     }
   }
 

--- a/cascalog-core/test/cascalog/cascading/conf_test.clj
+++ b/cascalog-core/test/cascalog/cascading/conf_test.clj
@@ -58,14 +58,14 @@
 
 (facts "Tests of various aspects of Kryo serialization."
   (with-job-conf
-    {"cascading.kryo.serializations" "java.util.DoesntExist"
-     "cascading.kryo.skip.missing" true
-     "cascading.kryo.accept.all" true}
+    {"com.twitter.chill.config.reflectinginstantiator.registrations" "java.util.DoesntExist,someSerializer"
+     "com.twitter.chill.config.reflectinginstantiator.skipmissing" true
+     "com.twitter.chill.config.reflectinginstantiator.registrationrequired" false}
     (let [cal-tuple [[(java.util.GregorianCalendar.)]]]
       (??<- [?a] (cal-tuple ?a)) => cal-tuple))
 
   (with-job-conf
-    {"cascading.kryo.accept.all" false}
+    {"com.twitter.chill.config.reflectinginstantiator.registrationrequired" true}
     (let [cal-tuple [[(java.util.GregorianCalendar.)]]]
       (fact
         "Attempting to serialize an unregistered object when


### PR DESCRIPTION
this is to restore the ability to specify kryo registration in the job conf ala cascading.kryo that I knocked out accidentally
