### PR TITLE
Adds test Travis-CI support for Cascalog-LZO

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,7 @@ jdk:
   - openjdk6
 notifications:
   email:
-    - timbers@ualberta.ca
+    - nathanmarz@gmail.com
+    - sritchie09@gmail.com
+    - paul@quantisan.com
+    - soren@dopeness.org


### PR DESCRIPTION
Fixes #129. About a year ago, the Travis-CI build failed due to a lack of native LZO libraries on the CI machine; this has since been fixed, and now the Travis-CI build passes. See my [fork](https://travis-ci.org/timbers/cascalog) for proof. 

As the Travis-CI build (currently) passes when Cascalog-LZO is added to project.clj, it should be added to project.clj in the main repo to guarantee test coverage.
