### PR TITLE
append to Cascading frameworks system property instead of setting it direclty

### DIFF
--- a/cascalog-core/src/clj/cascalog/cascading/conf.clj
+++ b/cascalog-core/src/clj/cascalog/cascading/conf.clj
@@ -108,7 +108,7 @@
 
 ;; being a good citizen in the cascading ecosystem and set the
 ;; framework property
-(System/setProperty AppProps/APP_FRAMEWORKS
+(AppProps/addApplicationFramework nil
                     (str "cascalog:" (get-version "cascalog/cascalog-core")))
 
 (defmacro with-job-conf


### PR DESCRIPTION
The AppProps class takes care of appending and deduplication. The old code would simply overwrite everything, which is not what we want.
