### PR TITLE
In-memory platform should handle seqs just like Cascading

### DIFF
--- a/cascalog-core/src/clj/cascalog/in_memory/platform.clj
+++ b/cascalog-core/src/clj/cascalog/in_memory/platform.clj
@@ -81,7 +81,8 @@
   (p/generator (or (seq v) ())))
 
 (defmethod p/generator [InMemoryPlatform clojure.lang.ISeq]
-  [v] v) 
+  [v]
+  (map s/collectify v))
 
 (defmethod p/generator [InMemoryPlatform java.util.ArrayList]
   [coll]

--- a/cascalog-core/test/cascalog/api_secondary_test.clj
+++ b/cascalog-core/test/cascalog/api_secondary_test.clj
@@ -195,3 +195,11 @@
     (test?- [[3 4] [2 1]]
             (c/first-n sq 2 :sort "?a" :reverse true))
     (is (= 2 (count (first (??- (c/first-n sq 2))))))))
+
+(deftest test-sequence-source
+  (test?<- [[1] [2] [3]]
+           [?n]
+           ([[1] [2] [3]] ?n))
+  (test?<- [[1] [2] [3]]
+           [?n]
+           ([1 2 3] ?n)))


### PR DESCRIPTION
Addresses [this](https://github.com/nathanmarz/cascalog/pull/256#issuecomment-68604347) comment