### PR TITLE
Follow api changes from v1.0 -> v2.0. 

### DIFF
--- a/cascalog-lzo/README.md
+++ b/cascalog-lzo/README.md
@@ -4,11 +4,24 @@ Based on the excellent work in Elephant-Bird:
 
     https://github.com/dvryaboy/elephant-bird/tree/eb-dev
 
+NOTE: If you just want to read .lzo files you just need to setup hadoop to do so. Then the normal `(hfs-textline "my_lzo_file.lzo")` will work. 
+AWS EMR is setup to include hadoop-lzo by default.
+
+### Configuring Hadoop
+
+You can find more information about Hadoop-LZO [on Cloudera](http://www.cloudera.com/blog/2009/11/hadoop-at-twitter-part-1-splittable-lzo-compression/).
+
+[Quick install guide](http://docs.hortonworks.com/HDPDocuments/HDP2/HDP-2.0.9.0/bk_installing_manually_book/content/rpm-chap2-3.html)
+
 ## Usage
 
 Add the following to `project.clj`:
 
-    [cascalog/cascalog-lzo "1.10.1-SNAPSHOT"]
+    [cascalog/cascalog-lzo "3.0.0-SNAPSHOT"]
+
+To use: `(:require [cascalog.lzo :as lzo])` and then create sinks or sources as `(lzo/hfs-lzo-textline directory)`
+
+Tested with hadoop 2.4 and 2.6.
 
 Stay tuned for updates!
 
@@ -21,20 +34,15 @@ On OS X:
 3. If you're on Lion, you'll have to re-install your java development headers [here](http://connect.apple.com/cgi-bin/WebObjects/MemberSite.woa/wa/download?path=%2FDeveloper_Tools%2Fjava_for_mac_os_x_10.7_update_1_developer_package%2Fjavadeveloper_for_mac_os_x_10.7__11m3527.dmg&wosid=Mo5ndLZsjioK2DIXcKKGLmyLffK).
 4. Download the [lzo native libs](https://github.com/nathanmarz/cascalog-contrib/downloads) and place them in `/opt/local/lib`.
 
-### Configuring Hadoop
-
-You can find more information about Hadoop-LZO [on Cloudera](http://www.cloudera.com/blog/2009/11/hadoop-at-twitter-part-1-splittable-lzo-compression/).
-
 ### Building Hadoop-Lzo
 
 This is only necessary if you're trying to rebuild this project.
 
 ```bash
-git clone https://github.com/kevinweil/hadoop-lzo.git
+git clone https://github.com/twitter/hadoop-lzo
 cd hadoop-lzo
-git checkout -b lion 4c5a2270863e0d906e5c3c7cd7a57a7f14436759
 
 JAVA_HOME=$(/usr/libexec/java_home) \
 C_INCLUDE_PATH=/opt/local/include LIBRARY_PATH=/opt/local/lib \
-CFLAGS="-arch x86_64" ant clean compile-native test tar
+CFLAGS="-arch x86_64" mvn clean test install
 ```

--- a/cascalog-lzo/project.clj
+++ b/cascalog-lzo/project.clj
@@ -6,14 +6,17 @@
   :description "Lzo compression taps for Cascalog."
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :repositories {"conjars.org" "http://conjars.org/repo"}
-  :dependencies [[com.twitter.elephantbird/elephant-bird-cascading2 "3.0.7"
+  :repositories {"conjars.org" "http://conjars.org/repo" "twttr.com" "http://maven.twttr.com/"}
+  :dependencies [[com.twitter.elephantbird/elephant-bird-cascading2 "4.6"
                   :exclusions [cascading/cascading-hadoop]]
-                 [hadoop-lzo "0.4.15"]]
+                 [com.hadoop.gplcompression/hadoop-lzo "0.4.19"]]
   :profiles {:1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
              :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
+             :1.5 {:dependencies [[org.clojure/clojure "1.5.0"]]}
+             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :provided {:dependencies [[cascalog/cascalog-core ~VERSION]
-                                       [org.apache.hadoop/hadoop-core ~HADOOP-VERSION]
+                                       [org.apache.hadoop/hadoop-common "2.4.0"]
+                                       [org.apache.hadoop/hadoop-mapreduce-client-jobclient "2.4.0"]
                                        [org.apache.httpcomponents/httpclient "4.2.3"]]}
              :dev {:dependencies [[cascalog/midje-cascalog ~VERSION]]
                    :plugins [[lein-midje "3.1.3"]]}})

--- a/cascalog-lzo/src/cascalog/lzo/impl.clj
+++ b/cascalog-lzo/src/cascalog/lzo/impl.clj
@@ -1,5 +1,5 @@
 (ns cascalog.lzo.impl
-  (:require [cascalog.workflow :as w])
+  (:require [cascalog.cascading.util :as util])
   (:import [com.twitter.elephantbird.cascading2.scheme
             LzoTextLine LzoTextDelimited LzoThriftScheme
             LzoProtobufScheme]))
@@ -9,12 +9,12 @@
   ([field-names]
      (text-line field-names field-names))
   ([source-fields sink-fields]
-     (LzoTextLine. (w/fields source-fields)
-                   (w/fields sink-fields))))
+     (LzoTextLine. (util/fields source-fields)
+                   (util/fields sink-fields))))
 
 (defn delimited [field-names klasses]
   (let [klasses (when klasses (into-array klasses))]
-    (-> (w/fields field-names)
+    (-> (util/fields field-names)
         (LzoTextDelimited. "\t"))))
 
 (defn thrift-b64-line [klass]


### PR DESCRIPTION
So, the underlying APIs have changed as well. If you compile pointing to Hadoop 1.2.1 (the current HADOOP-VERSION in the develop branch) you get an API changed error when running on Hadoop 2.4+. Here I manually pointed it at 2.4. Seems like we need a 'Cascalog 2 on Hadoop 1' branch and a separate 'Cascalog 2 on Hadoop 2' branch.