### PR TITLE
allow capture of filter results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - in-memory planner!
 
+
 From https://github.com/nathanmarz/cascalog/pull/270:
 - `:name` option allows you to supply a name to your flow via (:name "some name")
 - Schema validation on internal functions

--- a/cascalog-core/src/clj/cascalog/logic/predicate.clj
+++ b/cascalog-core/src/clj/cascalog/logic/predicate.clj
@@ -181,9 +181,10 @@
 
 (defmethod to-predicate ::d/map
   [op input output]
+  (def cake op)
   (if-let [output (not-empty output)]
     (Operation. op input output)
-    (FilterOperation. (-> op meta ::d/op) input)))
+    (FilterOperation. (d/filterop (-> op meta ::d/op)) input)))
 
 (defmethod to-predicate ::d/mapcat
   [op input output]

--- a/cascalog-core/src/clj/cascalog/logic/predicate.clj
+++ b/cascalog-core/src/clj/cascalog/logic/predicate.clj
@@ -175,11 +175,15 @@
 
 (defmethod to-predicate ::d/filter
   [op input output]
-  (FilterOperation. op input))
+  (if-let [output (not-empty output)]
+    (Operation. (d/mapop (-> op meta ::d/op)) input output)
+    (FilterOperation. op input)))
 
 (defmethod to-predicate ::d/map
   [op input output]
-  (Operation. op input output))
+  (if-let [output (not-empty output)]
+    (Operation. op input output)
+    (FilterOperation. (-> op meta ::d/op) input)))
 
 (defmethod to-predicate ::d/mapcat
   [op input output]

--- a/cascalog-core/test/cascalog/api_test.clj
+++ b/cascalog-core/test/cascalog/api_test.clj
@@ -640,6 +640,32 @@
               (people ?person)
               (bob-set ?person)) => (produces [["bob"]]))))
 
+(deftest test-filter-capture
+  (let [src [[1] [2]]]
+
+    (fact
+     "The result of filterops can be captured."
+     (<- [?x ?z]
+         (src ?x)
+         ((d/filterop odd?) ?x :> ?z)) => (produces [[1 true] [2 false]]))
+
+    (fact
+     "You can filter against the output of a filter too using a
+     literal:"
+     (<- [?x]
+         (src ?x)
+         ((d/filterop odd?) ?x :> false)) => (produces [[2]])
+
+     ", OR with a function:"
+     (<- [?x]
+         (src ?x)
+         ((d/filterop odd?) ?x :> false?)) => (produces [[2]]))
+
+    (fact "mapops can be used as filters if there are no output
+    variables:"
+          (<- [?x]
+              (src ?x)
+              ((d/mapop even?) ?x)) => (produces [[2]]))))
 
 (future-fact "test outer join with functions.")
 


### PR DESCRIPTION
Fixes https://github.com/nathanmarz/cascalog/issues/275.

This fix allows queries to capture the results of filter operations and guard them with boolean literals or function guards (`false?` and `true?`).

I also modified `mapop` so it can be used as a filter operation if you don't supply any output variables.