### PR TITLE
Propagate query names to (co)group steps

### DIFF
--- a/cascalog-core/test/cascalog/api_test.clj
+++ b/cascalog-core/test/cascalog/api_test.clj
@@ -131,7 +131,8 @@
              [?w ?c]
              (sentence ?s)
              (split ?s :> ?w)
-             (c/count ?c))))
+             (c/count ?c)
+             (:name "test-countall"))))
 
 (deftest test-multi-agg
   (let [value [["a" 1] ["a" 2] ["b" 10]
@@ -318,7 +319,8 @@
              [?p ?a !!f1 !!f2 !!f3]
              (age ?p ?a)
              (rec1 ?p !!f1 !!f2)
-             (rec2 ?p ?a !!f3))))
+             (rec2 ?p ?a !!f3)
+             (:name "outer-join-complex"))))
 
 (deftest test-outer-join-assertions
   (let [age [["a" 20] ["b" 30] ["c" 27] ["d" 40]]
@@ -375,7 +377,8 @@
              (age ?p !!a)
              (gender ?p !!g)
              (outer-join-tester3 !!a :> ?t)
-             (c/count ?c))
+             (c/count ?c)
+             (:name "count-test"))
 
     (test?<- [["A" "a"] ["E" nil]]
              [?p !!t]
@@ -477,7 +480,8 @@
     (test?<- [[4]]
              [?avg]
              (num1 ?n)
-             (c/avg ?n :> ?avg))
+             (c/avg ?n :> ?avg)
+             (:name "test-avg-1"))
 
     (test?<- [["a" 2] ["b" 3]]
              [?l ?avg]

--- a/cascalog-core/test/cascalog/cascading/operations_test.clj
+++ b/cascalog-core/test/cascalog/cascading/operations_test.clj
@@ -64,7 +64,7 @@
       (cascalog-join [(->Inner a ["a" "b" "c"])
                       (->Inner b ["a" "b"])]
                      ["a" "b"]
-                     [] :name "cascalog-test")
+                     [:name "cascalog-test"])
       => (produces [[3 4 16] [4 5 25]]))))
 
 (future-fact

--- a/cascalog-core/test/cascalog/cascading/operations_test.clj
+++ b/cascalog-core/test/cascalog/cascading/operations_test.clj
@@ -64,7 +64,7 @@
       (cascalog-join [(->Inner a ["a" "b" "c"])
                       (->Inner b ["a" "b"])]
                      ["a" "b"]
-                     [])
+                     [] :name "cascalog-test")
       => (produces [[3 4 16] [4 5 25]]))))
 
 (future-fact
@@ -134,9 +134,9 @@
         b      (-> source
                    (rename* ["x" "y"]))]
     (fact "Join joins stuff"
-      (-> (co-group* [a b] [["a"] ["x"]] :decl-fields ["a" "x" "b" "c" "y"])
+      (-> (co-group* [a b] [["a"] ["x"]] :decl-fields ["a" "x" "b" "c" "y"] :name "jjs")
           (map* str "y" "q"))
-      => (produces [[3 3 9 3 3 "3"] [4 4 16 4 4 "4"]]))
+      => (produces [[3 3 9 3 3 "3"] [4 4 16 4 4 "4"]] :info))
 
     (let [a (-> (generator [[1 1] [1 2] [2 2]]) (rename* ["a" "b"]))
           b (-> (generator [[1 10] [2 15]]) (rename* ["x" "y"]))


### PR DESCRIPTION
Uses `:name` query option to name CoGroup/GroupBy steps. 

I've updated unit tests to pass the name in some cases, but validation requires inspecting the logs manually.