### PR TITLE
skip over things in env not LocalBinding

### DIFF
--- a/cascalog-core/src/clj/cascalog/logic/fn.clj
+++ b/cascalog-core/src/clj/cascalog/logic/fn.clj
@@ -8,7 +8,9 @@
   (let [form (with-meta (cons `fn (rest form))
                (meta form))
         namespace (str *ns*)
-        savers (for [b bindings] [(str (.sym b)) (.sym b)])
+        savers (for [b bindings
+                      :when (instance? clojure.lang.Compiler$LocalBinding b)]
+                    [(str (.sym b)) (.sym b)])
         env-form `(into {} ~(vec savers))]
     ;; without the print-dup, it sometimes serializes invalid code
     ;; strings (with subforms replaced with "#")


### PR DESCRIPTION
Checked in Compiler.java, and LocalBinding is the only class with a public Symbol member named sym, so it's the only one that will work anyway.

Seems like the only time there are things in env that aren't LocalBinding is when the code is being run by tools.analyzer.

Fixes #274 

/cc @sritchie 