### PR TITLE
Allow operations that look like logic vars (e.g. !count) to be used without namespace

### DIFF
--- a/cascalog-core/src/clj/cascalog/api.clj
+++ b/cascalog-core/src/clj/cascalog/api.clj
@@ -91,7 +91,7 @@
   Syntax: (expand-query outvars & predicates)
 
   Ex: (expand-query [?person] (age ?person 25))"
-  `(v/with-logic-vars
+  `(v/with-logic-vars ~(cons outvars (map rest predicates))
      (let [{outvars# :output-fields
             predicates# :predicates}
            (parse/prepare-subquery ~outvars [~@(map vec predicates)])]

--- a/cascalog-core/src/clj/cascalog/logic/parse.clj
+++ b/cascalog-core/src/clj/cascalog/logic/parse.clj
@@ -160,14 +160,6 @@
   [vars]
   (not (some v/selector? vars)))
 
-(comment
-  "TODO: Make a test."
-  (v/with-logic-vars
-    (parse-subquery [?x ?y ?z]
-                    [[[[1 2 3]] ?x]
-                     [* ?x ?x :> ?y]
-                     [* ?x ?y :> ?z]])))
-
 ;; this is the root of the tree, used to account for all variables as
 ;; they're built up.
 
@@ -762,7 +754,7 @@ This won't work in distributed mode because of the ->Record functions."
   predicates. Predicate macros support destructuring of the input and
   output variables."
   [outvars & predicates]
-  `(v/with-logic-vars
+  `(v/with-logic-vars ~(cons outvars (map rest predicates))
      (parse-subquery ~outvars [~@(map vec predicates)])))
 
 (defn parse-exec-args

--- a/cascalog-core/src/clj/cascalog/logic/vars.clj
+++ b/cascalog-core/src/clj/cascalog/logic/vars.clj
@@ -133,14 +133,16 @@ interpreted as a logic variable."
   (every-pred symbol? reserved?))
 
 (defmacro with-logic-vars
-  "Binds all logic variables within the body of `with-logic-vars` to
-  their string equivalents, allowing the user to write bare symbols. For example:
+  "Binds all logic variables within the `to-search` of `with-logic-vars` to
+  their string equivalents, allowing the user to write bare symbols within the body.
 
-  (with-logic-vars
+ For example:
+
+  (with-logic-vars [?a ?b :see]
     (str ?a ?b :see))
   ;=>  \"?a?b:see\""
-  [& body]
-  (let [syms (->> (s/flatten body)
+  [to-search & body]
+  (let [syms (->> (s/flatten to-search)
                   (filter logic-sym?)
                   (distinct))]
     `(let [~@(mapcat (fn [s] [s (str s)]) syms)]


### PR DESCRIPTION
```with-logic-vars``` aggressively rebinds logic var looking symbols to strings. This makes it impossible to use operations that start with ! or ? in the query. I have a whole library of nil-friendly operations modeled after ops/!count that doesn't work because of this. In fact, you can't use ```!count``` without namespace either.