### PR TITLE
Expose access to group keys in buffer and aggregator

### DIFF
--- a/cascalog-core/src/clj/cascalog/cascading/operations.clj
+++ b/cascalog-core/src/clj/cascalog/cascading/operations.clj
@@ -26,6 +26,15 @@
             ClojureMonoidAggregator ClojureMonoidFunctor
             ClojureAggregateBy CombinerSpec]))
 
+;; ## Dynamic Variables
+;;
+;; These variables are bound within the context of a Cascalog job. You
+;; can access them from your operations without worry about prepfn
+;; craziness.
+
+(def ^:dynamic *flow-process* nil)
+(def ^:dynamic *op-call* nil)
+
 ;; ## Operations
 ;;
 ;; All of these operations work on implementers of the Generator

--- a/cascalog-core/src/clj/cascalog/cascading/stats.clj
+++ b/cascalog-core/src/clj/cascalog/cascading/stats.clj
@@ -1,7 +1,8 @@
 (ns cascalog.cascading.stats
   "Namespace implementing stats processing for the Cascading planner."
   (:require [clojure.string :refer [join]]
-            [schema.core :as s])
+            [schema.core :as s]
+            [cascalog.cascading.operations :refer [*flow-process*]])
   (:import [cascading.stats CascadingStats]))
 
 ;; ## Schemas
@@ -29,15 +30,6 @@
    :skipped? s/Bool
    :stopped? s/Bool
    :successful? s/Bool})
-
-;; ## Dynamic Variables
-;;
-;; These variables are bound within the context of a Cascalog job. You
-;; can access them from your operations without worry about prepfn
-;; craziness.
-
-(def ^:dynamic *flow-process* nil)
-(def ^:dynamic *op-call* nil)
 
 (def default-group
   "This is the default group name for any stats recorded in the course

--- a/cascalog-core/src/java/cascalog/ClojureCascadingBase.java
+++ b/cascalog-core/src/java/cascalog/ClojureCascadingBase.java
@@ -53,8 +53,8 @@ public class ClojureCascadingBase extends BaseOperation {
   @Override
   public void prepare(FlowProcess fp, OperationCall call) {
     this.bindingMap = PersistentHashMap
-      .create(Util.getVar("cascalog.cascading.stats", "*flow-process*"), fp,
-              Util.getVar("cascalog.cascading.stats", "*op-call*"), call);
+      .create(Util.getVar("cascalog.cascading.operations", "*flow-process*"), fp,
+              Util.getVar("cascalog.cascading.operations", "*op-call*"), call);
 
     IFn fn = Util.deserializeFn(serializedFn);
 

--- a/cascalog-core/src/java/cascalog/ClojureCombinerBase.java
+++ b/cascalog-core/src/java/cascalog/ClojureCombinerBase.java
@@ -1,14 +1,14 @@
 /*
     Copyright 2010 Nathan Marz
- 
-    Project and contact information: http://www.cascalog.org/ 
+
+    Project and contact information: http://www.cascalog.org/
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-   
+
         http://www.apache.org/licenses/LICENSE-2.0
-   
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -82,8 +82,8 @@ public abstract class ClojureCombinerBase extends BaseOperation implements Funct
   @Override
   public void prepare(FlowProcess flowProcess, OperationCall operationCall) {
     this.bindingMap = PersistentHashMap
-        .create(Util.getVar("cascalog.cascading.stats", "*flow-process*"), flowProcess,
-            Util.getVar("cascalog.cascading.stats", "*op-call*"), operationCall);
+        .create(Util.getVar("cascalog.cascading.operations", "*flow-process*"), flowProcess,
+            Util.getVar("cascalog.cascading.operations", "*op-call*"), operationCall);
 
     JobConf jc = ((HadoopFlowProcess) flowProcess).getJobConf();
     this.cacheSize = jc.getInt(this.cacheConfArg, this.defaultCacheSize);

--- a/cascalog-core/src/java/cascalog/Util.java
+++ b/cascalog-core/src/java/cascalog/Util.java
@@ -145,7 +145,7 @@ public class Util {
   }
 
   public static List<Object> tupleToList(Tuple tuple) {
-    List<Object> ret = new ArrayList<Object>();
+    List<Object> ret = new ArrayList<Object>(tuple.size());
     tupleIntoList(ret, tuple);
     return ret;
   }
@@ -155,9 +155,7 @@ public class Util {
   }
 
   public static List<Object> toList(Object[] arr) {
-    List<Object> ret = new ArrayList<Object>();
-    Collections.addAll(ret, arr);
-    return ret;
+      return Arrays.asList((Object[])arr);
   }
 
   public static Configuration clojureConf() {


### PR DESCRIPTION
Note this doesn't work for parallel aggregators because Cascading doesn't give access to keys in the AggregateBy.Functor