### PR TITLE
fix #295, due to iterator-seq change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ language: clojure
 lein: lein2
 script: JVM_OPTS="-Djava.library.path=$PWD/hadoop-lzo-native/lib" lein2 sub with-profile dev,provided test
 before_install:
+    - cat /etc/hosts # optionally check the content *before*
+    - sudo hostname "$(hostname | cut -c1-63)"
+    - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
+    - cat /etc/hosts # optionally check the content *after*
     - lein2 sub install
     - sudo apt-get update -qq
     - sudo apt-get install -qq protobuf-compiler

--- a/cascalog-core/project.clj
+++ b/cascalog-core/project.clj
@@ -34,6 +34,8 @@
   :profiles {:1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
              :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
+             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
+             :1.7 {:denpedencies [[org.clojure/clojure "1.7.0"]]}
              :provided {:dependencies [[org.apache.hadoop/hadoop-core ~HADOOP-VERSION]]}
              :dev {:resource-paths ["dev"]
                    :plugins [[lein-midje "3.1.3"]]

--- a/cascalog-core/src/clj/cascalog/cascading/tap.clj
+++ b/cascalog-core/src/clj/cascalog/cascading/tap.clj
@@ -7,7 +7,7 @@
            [cascalog Util]
            [cascading.tap Tap SinkMode]
            [cascading.tap.hadoop Hfs Lfs GlobHfs TemplateTap]
-           [cascading.tuple TupleEntryCollector]
+           [cascading.tuple TupleEntryCollector TupleEntryIterator]
            [cascading.scheme Scheme]
            [cascading.scheme.hadoop TextLine TextLine$Compress SequenceFile TextDelimited]
            [cascading.flow.hadoop HadoopFlowProcess]
@@ -236,7 +236,7 @@ identity.  identity."
        (MemorySourceTap. tuples (fields fields-in)))))
 
 ;; ## Tap Helpers
-(defn iter-seq [iter f]
+(defn iter-seq [^TupleEntryIterator iter f]
   (if (.hasNext iter)
     (lazy-seq
       (cons (f (.next iter))

--- a/cascalog-core/src/clj/cascalog/cascading/tap.clj
+++ b/cascalog-core/src/clj/cascalog/cascading/tap.clj
@@ -245,8 +245,8 @@ identity.  identity."
 (defn pluck-tuple [^Tap tap]
   (with-open [it (-> (HadoopFlowProcess. (hadoop/job-conf (conf/project-conf)))
                      (.openTapForRead tap))]
-    (if-let [iter (iterator-seq it)]
-      (-> iter first .getTuple Tuple. Util/coerceFromTuple vec)
+    (if-let [iter (iter-seq it #(.getTupleCopy %))]
+      (-> iter first Tuple. Util/coerceFromTuple vec)
       (throw-illegal "Cascading tap is empty -- tap must contain tuples."))))
 
 (defn get-sink-tuples [^Tap sink]

--- a/cascalog-core/test/cascalog/api_test.clj
+++ b/cascalog-core/test/cascalog/api_test.clj
@@ -801,7 +801,7 @@
              [?l]
              (kv ?l ?n))))
 
-(deftest test-multi-query-parrel
+(deftest test-multi-query-parallel
   (let [test-data [["ben" 35]
                    ["jerry" 41]]]
     (??- (<- [?name ?age]

--- a/cascalog-core/test/cascalog/api_test.clj
+++ b/cascalog-core/test/cascalog/api_test.clj
@@ -800,3 +800,15 @@
     (test?<- ["a"]
              [?l]
              (kv ?l ?n))))
+
+(deftest test-multi-query-parrel
+  (let [test-data [["ben" 35]
+                   ["jerry" 41]]]
+    (??- (<- [?name ?age]
+             (test-data ?name ?age)
+             (< ?age 40))
+         (<- [?name ?age]
+             (test-data ?name ?age)
+             (< ?age 50)))
+    => (produces [["ben" 35]
+                  [["ben" 35] ["jerry" 41]]])))


### PR DESCRIPTION
happy. ^_^

I changed  cascalog-core/project.clj   dep to [org.clojure/clojure "1.7.0"]
modify iterator-seq to iter-seq.

it works. mutli-results:
user=> multi-results
((["ben" 35]) (["ben" 35] ["jerry" 41]))

I don't know another iterator-seq(tap.clj/pluck-tuple) weather has the same bug.

but it fix  ??- 