### PR TITLE
Added support for chaining (select-fields) after cascading DSL flow

### DIFF
--- a/cascalog-core/src/clj/cascalog/cascading/platform.clj
+++ b/cascalog-core/src/clj/cascalog/cascading/platform.clj
@@ -31,7 +31,7 @@
            [cascalog.cascading.operations IAggregateBy IAggregator
             Inner Outer Existence]
            [cascalog.logic.def ParallelAggregator ParallelBuffer Prepared]
-           [cascalog.cascading.types CascadingPlatform]
+           [cascalog.cascading.types CascadingPlatform ClojureFlow]
            [com.twitter.maple.tap MemorySourceTap]
            [cascading.tap Tap]
            [cascalog.cascading.tap CascalogTap]
@@ -385,4 +385,8 @@
   CascalogTap
   (select-fields [tap fields]
     (-> (p/generator tap)
-        (ops/select* fields))))
+        (ops/select* fields)))
+
+  ClojureFlow
+  (select-fields [flow fields]
+    (ops/select* flow fields)))

--- a/cascalog-core/test/cascalog/cascading/flow_test.clj
+++ b/cascalog-core/test/cascalog/cascading/flow_test.clj
@@ -54,3 +54,14 @@
                ((d/bufferop* +) ?a :> ?z)
                ((d/mapcatop* +) ?a 10 :> ?b))]
     (clojure.pprint/pprint (build-rule sq))))
+
+
+(deftest select-from-flow
+  (let [data [[1] [2] [3] [4]]
+        flow (-> (p/generator data)
+                 (ops/rename* ["a"])
+                 (ops/map* square "a" "a2"))
+        gen (select-fields flow ["a"]) ]
+    (fact (<- [?b]
+              (gen ?b))
+          => (produces data))))


### PR DESCRIPTION
This used to fail since ClojureFlow did not support ISelectFields protocol. 
